### PR TITLE
Update map-style.ts

### DIFF
--- a/components/map-style.ts
+++ b/components/map-style.ts
@@ -44,6 +44,6 @@ export const parcelHighlightLayer: LayerProps = {
   type: "fill",
   paint: {
     "fill-color": "#2FC1C1",
-    "fill-opacity": 1.0,
+    "fill-opacity": 0.75,
   },
 };


### PR DESCRIPTION
Lighten the opacity of highlighted parcels so the user can still see the underlying map/satellite elements.