### PR TITLE
fix: Media Gallery pins are failing 

### DIFF
--- a/lib/GeoWebBucket.ts
+++ b/lib/GeoWebBucket.ts
@@ -131,6 +131,9 @@ export class GeoWebBucket extends TileStreamManager<Pinset> {
       this.latestPinnedRoot
     );
     console.debug(`Found latestPinnedLinks: ${this.latestPinnedLinks}`);
+
+    // Reload stream
+    await this.ceramic.loadStream(this.stream!.id);
   }
 
   async triggerPin() {


### PR DESCRIPTION
Fixes #169 

This fixes what appears to be a regression in pinning logic. There are still improvements to make to improve pinning performance. I have some ideas, but for now this PR should restore the performance to what it was in the previous testnet.