### PR TITLE
fix: Update transaction error modal for a custom message

### DIFF
--- a/components/cards/ActionForm.tsx
+++ b/components/cards/ActionForm.tsx
@@ -6,11 +6,10 @@ import { ethers, BigNumber } from "ethers";
 import Image from "react-bootstrap/Image";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
-import Alert from "react-bootstrap/Alert";
 import {
   PAYMENT_TOKEN,
   NETWORK_ID,
-  SECONDS_IN_YEAR,
+  SECONDS_IN_YEAR
 } from "../../lib/constants";
 import BN from "bn.js";
 import { SidebarProps } from "../Sidebar";
@@ -25,6 +24,7 @@ import { AssetId } from "caip";
 import { model as GeoWebModel } from "@geo-web/datamodels";
 import { DataModel } from "@glazed/datamodel";
 import { AssetContentManager } from "../../lib/AssetContentManager";
+import TransactionError from "./TransactionError";
 
 export type ActionFormProps = SidebarProps & {
   perSecondFeeNumerator: BigNumber;
@@ -47,6 +47,7 @@ export type ActionData = {
   displayCurrentForSalePrice?: string;
   didFail?: boolean;
   isActing?: boolean;
+  errorMessage?: string;
 };
 
 export function ActionForm(props: ActionFormProps) {
@@ -67,7 +68,7 @@ export function ActionForm(props: ActionFormProps) {
     paymentToken,
     summaryView,
     requiredBid,
-    hasOutstandingBid = false,
+    hasOutstandingBid = false
   } = props;
 
   const {
@@ -77,6 +78,7 @@ export function ActionForm(props: ActionFormProps) {
     displayCurrentForSalePrice,
     didFail,
     isActing,
+    errorMessage
   } = actionData;
   const [showWrapModal, setShowWrapModal] = React.useState(false);
 
@@ -93,7 +95,7 @@ export function ActionForm(props: ActionFormProps) {
     <Image
       style={{
         width: "1.1rem",
-        marginLeft: "4px",
+        marginLeft: "4px"
       }}
       src="info.svg"
     />
@@ -148,7 +150,11 @@ export function ActionForm(props: ActionFormProps) {
       parcelId = await performAction();
     } catch (err) {
       console.error(err);
-      updateActionData({ isActing: false, didFail: true });
+      updateActionData({
+        isActing: false,
+        didFail: true,
+        errorMessage: err.errorObject.reason.replace("execution reverted: ", "")
+      });
       return;
     }
 
@@ -165,14 +171,14 @@ export function ActionForm(props: ActionFormProps) {
         chainId: `eip155:${NETWORK_ID}`,
         assetName: {
           namespace: "erc721",
-          reference: licenseAddress.toLowerCase(),
+          reference: licenseAddress.toLowerCase()
         },
-        tokenId: parcelId.toString(),
+        tokenId: parcelId.toString()
       });
 
       const model = new DataModel({
         ceramic,
-        aliases: GeoWebModel,
+        aliases: GeoWebModel
       });
 
       const _assetContentManager = new AssetContentManager(
@@ -367,18 +373,7 @@ export function ActionForm(props: ActionFormProps) {
 
           <br />
           {didFail && !isActing ? (
-            <Alert
-              variant="danger"
-              dismissible
-              onClick={() => updateActionData({ didFail: false })}
-            >
-              <Alert.Heading style={{ fontSize: "1em" }}>
-                Transaction failed
-              </Alert.Heading>
-              <p style={{ fontSize: "0.8em" }}>
-                Oops! Something went wrong. Please try again.
-              </p>
-            </Alert>
+            <TransactionError message={errorMessage} />
           ) : null}
         </Card.Body>
         <Card.Footer className="border-top border-secondary">

--- a/components/cards/OutstandingBidView.tsx
+++ b/components/cards/OutstandingBidView.tsx
@@ -10,15 +10,15 @@ import utc from "dayjs/plugin/utc";
 import advancedFormat from "dayjs/plugin/advancedFormat";
 import Button from "react-bootstrap/Button";
 import { fromValueToRate } from "../../lib/utils";
-import Alert from "react-bootstrap/Alert";
 import { STATE } from "../Map";
+import TransactionError from "./TransactionError";
 
 dayjs.extend(utc);
 dayjs.extend(advancedFormat);
 
 enum Action {
   CLAIM,
-  BID,
+  BID
 }
 
 type OutstandingBidViewProps = SidebarProps & {
@@ -44,10 +44,11 @@ function OutstandingBidView({
   perSecondFeeDenominator,
   sfFramework,
   setInteractionState,
-  setSelectedParcelId,
+  setSelectedParcelId
 }: OutstandingBidViewProps) {
   const [isActing, setIsActing] = React.useState(false);
   const [didFail, setDidFail] = React.useState(false);
+  const [errorMessage, setErrorMessage] = React.useState("");
 
   const newForSalePriceDisplay = truncateEth(
     formatBalance(newForSalePrice),
@@ -135,7 +136,7 @@ function OutstandingBidView({
       superToken: paymentToken.address,
       sender: account,
       receiver: auctionSuperApp.address,
-      providerOrSigner: provider as any,
+      providerOrSigner: provider as any
     });
 
     const signer = provider.getSigner() as any;
@@ -145,7 +146,7 @@ function OutstandingBidView({
       op = sfFramework.cfaV1.deleteFlow({
         sender: account,
         receiver: auctionSuperApp.address,
-        superToken: paymentToken.address,
+        superToken: paymentToken.address
       });
     } else {
       op = sfFramework.cfaV1.updateFlow({
@@ -154,7 +155,7 @@ function OutstandingBidView({
           .toString(),
         receiver: auctionSuperApp.address,
         superToken: paymentToken.address,
-        userData,
+        userData
       });
     }
 
@@ -163,6 +164,9 @@ function OutstandingBidView({
       await txn.wait();
     } catch (err) {
       console.error(err);
+      setErrorMessage(
+        err.errorObject.reason.replace("execution reverted: ", "")
+      );
       setDidFail(true);
       setIsActing(false);
       return;
@@ -185,6 +189,9 @@ function OutstandingBidView({
       await txn.wait();
     } catch (err) {
       console.error(err);
+      setErrorMessage(
+        err.errorObject.reason.replace("execution reverted: ", "")
+      );
       setDidFail(true);
       setIsActing(false);
       return;
@@ -247,14 +254,7 @@ function OutstandingBidView({
           </Button>
         ) : null}
         {didFail && !isActing ? (
-          <Alert variant="danger" dismissible onClick={() => setDidFail(false)}>
-            <Alert.Heading style={{ fontSize: "1em" }}>
-              Transaction failed
-            </Alert.Heading>
-            <p style={{ fontSize: "0.8em" }}>
-              Oops! Something went wrong. Please try again.
-            </p>
-          </Alert>
+          <TransactionError message={errorMessage} />
         ) : null}
       </Card.Body>
     </Card>

--- a/components/cards/PlaceBidAction.tsx
+++ b/components/cards/PlaceBidAction.tsx
@@ -10,13 +10,13 @@ import Card from "react-bootstrap/Card";
 import Form from "react-bootstrap/Form";
 import { truncateEth } from "../../lib/truncate";
 import Col from "react-bootstrap/Col";
-import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Image from "react-bootstrap/Image";
 import Row from "react-bootstrap/Row";
 import WrapModal from "../wrap/WrapModal";
 import { STATE } from "../Map";
 import InfoTooltip from "../InfoTooltip";
+import TransactionError from "./TransactionError";
 
 export type PlaceBidActionProps = SidebarProps & {
   perSecondFeeNumerator: BigNumber;
@@ -26,14 +26,14 @@ export type PlaceBidActionProps = SidebarProps & {
 
 enum Action {
   CLAIM,
-  BID,
+  BID
 }
 
 const infoIcon = (
   <Image
     style={{
       width: "1.1rem",
-      marginLeft: "4px",
+      marginLeft: "4px"
     }}
     src="info.svg"
   />
@@ -50,14 +50,16 @@ function PlaceBidAction(props: PlaceBidActionProps) {
     account,
     auctionSuperApp,
     sfFramework,
-    setInteractionState,
+    setInteractionState
   } = props;
 
   const [showWrapModal, setShowWrapModal] = React.useState(false);
   const [didFail, setDidFail] = React.useState(false);
+  const [errorMessage, setErrorMessage] = React.useState("");
   const [isActing, setIsActing] = React.useState(false);
-  const [displayNewForSalePrice, setDisplayNewForSalePrice] =
-    React.useState<string | null>(null);
+  const [displayNewForSalePrice, setDisplayNewForSalePrice] = React.useState<
+    string | null
+  >(null);
 
   const handleWrapModalOpen = () => setShowWrapModal(true);
   const handleWrapModalClose = () => setShowWrapModal(false);
@@ -145,13 +147,13 @@ function PlaceBidAction(props: PlaceBidActionProps) {
       superToken: paymentToken.address,
       sender: account,
       receiver: auctionSuperApp.address,
-      providerOrSigner: provider as any,
+      providerOrSigner: provider as any
     });
 
     // Approve amount above purchase price
     const approveOp = paymentToken.approve({
       receiver: auctionSuperApp.address,
-      amount: newForSalePrice.toString(),
+      amount: newForSalePrice.toString()
     });
 
     const signer = provider.getSigner() as any;
@@ -164,14 +166,14 @@ function PlaceBidAction(props: PlaceBidActionProps) {
           .toString(),
         receiver: auctionSuperApp.address,
         superToken: paymentToken.address,
-        userData,
+        userData
       });
     } else {
       op = sfFramework.cfaV1.createFlow({
         receiver: auctionSuperApp.address,
         flowRate: newNetworkFee.toString(),
         superToken: paymentToken.address,
-        userData,
+        userData
       });
     }
 
@@ -182,6 +184,9 @@ function PlaceBidAction(props: PlaceBidActionProps) {
       await txn.wait();
     } catch (err) {
       console.error(err);
+      setErrorMessage(
+        err.errorObject.reason.replace("execution reverted: ", "")
+      );
       setDidFail(true);
       setIsActing(false);
       return;
@@ -311,18 +316,7 @@ function PlaceBidAction(props: PlaceBidActionProps) {
 
           <br />
           {didFail && !isActing ? (
-            <Alert
-              variant="danger"
-              dismissible
-              onClick={() => setDidFail(false)}
-            >
-              <Alert.Heading style={{ fontSize: "1em" }}>
-                Transaction failed
-              </Alert.Heading>
-              <p style={{ fontSize: "0.8em" }}>
-                Oops! Something went wrong. Please try again.
-              </p>
-            </Alert>
+            <TransactionError message={errorMessage} />
           ) : null}
         </Card.Body>
         <Card.Footer className="border-top border-secondary">

--- a/components/cards/TransactionError.tsx
+++ b/components/cards/TransactionError.tsx
@@ -11,7 +11,9 @@ function TransactionError(props: TransactionErrorProps) {
         Transaction Failed
       </Alert.Heading>
       <p style={{ fontSize: "0.8em" }}>{`Something went wrong: ${
-        props.message ? props.message : "unknown reason"
+        props.message
+          ? props.message.replace(/([^.])$/, "$1.")
+          : "unknown reason."
       }`}</p>
     </Alert>
   );

--- a/components/cards/TransactionError.tsx
+++ b/components/cards/TransactionError.tsx
@@ -1,0 +1,20 @@
+import Alert from "react-bootstrap/Alert";
+
+export type TransactionErrorProps = {
+  message?: string;
+};
+
+function TransactionError(props: TransactionErrorProps) {
+  return (
+    <Alert variant="danger">
+      <Alert.Heading style={{ fontSize: "1em" }}>
+        Transaction Failed
+      </Alert.Heading>
+      <p style={{ fontSize: "0.8em" }}>{`Something went wrong: ${
+        props.message ? props.message : "unknown reason"
+      }`}</p>
+    </Alert>
+  );
+}
+
+export default TransactionError;


### PR DESCRIPTION
This PR aims to fix the issue #205 by adding:
- Custom error messages on transaction modals
- Removing the close icon as it is not possible right now with different bootstrap and react-bootstrap versions
- Capitalize error message
- Creating a custom modal for TransactionError