### PR TITLE
fix: use correct API key to get Infura provider

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -71,7 +71,7 @@ function IndexPage() {
       chainId: NETWORK_ID,
       provider: new ethers.providers.InfuraProvider(
         NETWORK_ID,
-        process.env.NEXT_PUBLIC_INFURA_ID
+        process.env.NEXT_PUBLIC_INFURA_PROJECT_ID
       ),
     });
     setSfFramework(framework);

--- a/redux/store.ts
+++ b/redux/store.ts
@@ -31,7 +31,7 @@ export const makeStore = () => {
       chainId: NETWORK_ID,
       provider: new ethers.providers.InfuraProvider(
         NETWORK_ID,
-        process.env.NEXT_PUBLIC_INFURA_ID
+        process.env.NEXT_PUBLIC_INFURA_PROJECT_ID
       ),
     });
   });


### PR DESCRIPTION
# Pull Request Template

## Description

We are using the default ethers.js provider, which has a low rate limit, because the environment variable passed to the function returning the provider is not defined in the `.env` file.
Passing the correct environment variable gives us a provider with higher rate limit.

fixes #227 

## Checklist:

- [x] My commit message follows the Conventional Commits specificaiton
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

## Alert Reviewers

@codynhat @gravenp 


