### PR TITLE
Fix/large parcels fully displayed

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -288,6 +288,7 @@ function Map(props: MapProps) {
     id: string;
     timerId: number | null;
   }>({ id: "", timerId: null });
+  const [lastDataLength, setLastDataLength] = useState<number>(0);
 
   const isGridVisible =
     viewport.zoom >= ZOOM_GRID_LEVEL &&
@@ -323,6 +324,12 @@ function Map(props: MapProps) {
     };
   }, [data, newParcel.id, fetchMore]);
 
+  useEffect(() => {
+    if (data?.geoWebCoordinates.length) {
+      setLastDataLength(data?.geoWebCoordinates.length);
+    }
+  }, [data]);
+
   const flyToLocation = useCallback(
     ({
       longitude,
@@ -353,15 +360,8 @@ function Map(props: MapProps) {
 
     if (data.geoWebCoordinates.length > 0) {
       if (
-        data.geoWebCoordinates.every((element, index) => {
-          if (
-            !index ||
-            (element.parcel.id === data.geoWebCoordinates[0].parcel.id &&
-              element.id !== data.geoWebCoordinates[0].id)
-          ) {
-            return true;
-          }
-        })
+        data.geoWebCoordinates.length === 1000 ||
+        data.geoWebCoordinates.length - lastDataLength === 1000
       ) {
         const lastElement =
           data.geoWebCoordinates[data.geoWebCoordinates.length - 1];
@@ -387,6 +387,7 @@ function Map(props: MapProps) {
             ...params,
           },
         });
+        return;
       } else {
         newLastBlock =
           data.geoWebCoordinates[data.geoWebCoordinates.length - 1]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "esnext",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
# Description

Gql queries return at max 1000 entries, which causes issues with displaying parcels over 1000 coordinates. Currently the app gets the first 1000 coordinates and then moves onto the next parcel, which is why the larger parcels don't display properly.

This solution checks if the previous query returned 1000 entries, and then paginates based on the last coordinate ID received until an empty list is returned(signifying the end of the parcel)

Targets esnext instead of es5 for BigInt support

# Issue

fixes #223 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it

# Alert Reviewers

@codynhat @gravenp
