### PR TITLE
fix: update block explorer to Goerli Etherscan

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -8,7 +8,7 @@ export const SUBGRAPH_URL =
 export const CERAMIC_URL = "https://g12-a-ceramic.3boxlabs.com/";
 export const CONNECT_NETWORK = "mainnet";
 export const CERAMIC_EXPLORER = `https://cerscan.com/${CONNECT_NETWORK}/stream`;
-export const BLOCK_EXPLORER = `https://goerli-optimism.etherscan.io`;
+export const BLOCK_EXPLORER = `https://goerli.etherscan.io`;
 export const RPC_URLS = {
   4: `https://rinkeby.infura.io/v3/${process.env.NEXT_PUBLIC_INFURA_PROJECT_ID}`,
   5: `https://goerli.infura.io/v3/${process.env.NEXT_PUBLIC_INFURA_PROJECT_ID}`,


### PR DESCRIPTION
Update the block explorer link to point to the right network (Goerli)

# Description

Changes the `BLOCK_EXPLORER` value to the Goerli Etherscan link

# Issue

N/A

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code
- [ ] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat 
