### PR TITLE
fix: conserve parcel content on reclaim

### DIFF
--- a/components/cards/ParcelInfo.tsx
+++ b/components/cards/ParcelInfo.tsx
@@ -623,6 +623,7 @@ function ParcelInfo(props: ParcelInfoProps) {
           {interactionState == STATE.PARCEL_RECLAIMING && licenseOwner ? (
             <ReclaimAction
               {...props}
+              basicProfileStreamManager={basicProfileStreamManager}
               licenseOwner={licenseOwner}
               licenseDiamondContract={licenseDiamondContract}
               requiredBid={requiredBid ?? undefined}

--- a/components/cards/ReclaimAction.tsx
+++ b/components/cards/ReclaimAction.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { BigNumber, ethers } from "ethers";
+import { BasicProfileStreamManager } from "../../lib/stream-managers/BasicProfileStreamManager";
 import { ActionData, ActionForm } from "./ActionForm";
 import { SidebarProps, ParcelFieldsToUpdate } from "../Sidebar";
 import StreamingInfo from "./StreamingInfo";
@@ -12,6 +13,7 @@ import BN from "bn.js";
 export type ReclaimActionProps = SidebarProps & {
   perSecondFeeNumerator: BigNumber;
   perSecondFeeDenominator: BigNumber;
+  basicProfileStreamManager: BasicProfileStreamManager | null;
   requiredBid?: BigNumber;
   licenseOwner: string;
   licenseDiamondContract: PCOLicenseDiamond | null;
@@ -24,6 +26,7 @@ function ReclaimAction(props: ReclaimActionProps) {
   const {
     account,
     provider,
+    basicProfileStreamManager,
     licenseOwner,
     requiredBid,
     perSecondFeeNumerator,
@@ -87,6 +90,19 @@ function ReclaimAction(props: ReclaimActionProps) {
 
     run();
   }, [sfFramework, paymentToken, displayNewForSalePrice]);
+
+  React.useEffect(() => {
+    const parcelContent = basicProfileStreamManager
+      ? basicProfileStreamManager.getStreamContent()
+      : null;
+
+    if (parcelContent && licenseOwner === account) {
+      updateActionData({
+        parcelName: parcelContent.name,
+        parcelWebContentURI: parcelContent.url,
+      });
+    }
+  }, [basicProfileStreamManager]);
 
   function updateActionData(updatedValues: ActionData) {
     function _updateData(updatedValues: ActionData) {


### PR DESCRIPTION
# Description

Maintain the parcel content when a licensor reclaims their parcel.

# Issue

fixes #262 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
