### PR TITLE
fix: allow dutch auction to go below min for sale price for foreclose…

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -19,7 +19,7 @@ import Image from "react-bootstrap/Image";
 
 import { CeramicClient } from "@ceramicnetwork/http-client";
 import "@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css";
-import { ethers, BigNumber } from "ethers";
+import { ethers } from "ethers";
 import "mapbox-gl/dist/mapbox-gl.css";
 
 import { Framework, NativeAssetSuperToken } from "@superfluid-finance/sdk-core";
@@ -205,7 +205,6 @@ export type MapProps = {
   >;
   isPortfolioToUpdate: boolean;
   setIsPortfolioToUpdate: React.Dispatch<React.SetStateAction<boolean>>;
-  minForSalePrice: BigNumber;
 };
 
 const MAP_STYLE_KEY = "storedMapStyleName";

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -34,7 +34,6 @@ function Sidebar(props: SidebarProps) {
     setInteractionState,
     parcelClaimSize,
     selectedParcelCoords,
-    minForSalePrice,
   } = props;
 
   const [perSecondFeeNumerator, setPerSecondFeeNumerator] =
@@ -55,16 +54,20 @@ function Sidebar(props: SidebarProps) {
       .then((_perSecondFeeDenominator) => {
         setPerSecondFeeDenominator(_perSecondFeeDenominator);
       });
+    registryContract.getMinForSalePrice().then((_minForSalePrice) => {
+      setMinForSalePrice(_minForSalePrice);
+    });
   }, [registryContract]);
 
   const [startingBid, setStartingBid] = React.useState<BigNumber | null>(null);
   const [endingBid, setEndingBid] = React.useState<BigNumber | null>(null);
-  const [auctionStart, setAuctionStart] = React.useState<BigNumber | null>(
-    null
-  );
+  const [auctionStart, setAuctionStart] =
+    React.useState<BigNumber | null>(null);
   const [auctionEnd, setAuctionEnd] = React.useState<BigNumber | null>(null);
   const [requiredBid, setRequiredBid] =
-    React.useState<BigNumber>(minForSalePrice);
+    React.useState<BigNumber>(BigNumber.from(0));
+  const [minForSalePrice, setMinForSalePrice] =
+    React.useState<BigNumber | null>(null);
 
   React.useEffect(() => {
     let isMounted = true;
@@ -116,11 +119,14 @@ function Sidebar(props: SidebarProps) {
           setRequiredBid={setRequiredBid}
           {...props}
         />
-      ) : perSecondFeeNumerator && perSecondFeeDenominator ? (
+      ) : perSecondFeeNumerator &&
+        perSecondFeeDenominator &&
+        minForSalePrice ? (
         <ParcelInfo
           {...props}
           perSecondFeeNumerator={perSecondFeeNumerator}
           perSecondFeeDenominator={perSecondFeeDenominator}
+          minForSalePrice={minForSalePrice}
           selectedParcelCoords={selectedParcelCoords}
           parcelFieldsToUpdate={parcelFieldsToUpdate}
           setParcelFieldsToUpdate={setParcelFieldsToUpdate}
@@ -134,7 +140,8 @@ function Sidebar(props: SidebarProps) {
       ) : null}
       {interactionState == STATE.CLAIM_SELECTED &&
       perSecondFeeNumerator &&
-      perSecondFeeDenominator ? (
+      perSecondFeeDenominator &&
+      minForSalePrice ? (
         <>
           <ClaimAction
             {...props}
@@ -143,6 +150,7 @@ function Sidebar(props: SidebarProps) {
             perSecondFeeNumerator={perSecondFeeNumerator}
             perSecondFeeDenominator={perSecondFeeDenominator}
             requiredBid={requiredBid}
+            minForSalePrice={minForSalePrice}
             setParcelFieldsToUpdate={setParcelFieldsToUpdate}
           ></ClaimAction>
         </>

--- a/components/cards/ActionForm.tsx
+++ b/components/cards/ActionForm.tsx
@@ -44,6 +44,7 @@ export type ActionFormProps = SidebarProps & {
   requiredFlowPermissions: number | null;
   spender: string | null;
   flowOperator: string | null;
+  minForSalePrice: BigNumber;
 };
 
 export type ActionData = {
@@ -112,7 +113,11 @@ export function ActionForm(props: ActionFormProps) {
     (isNaN(Number(displayNewForSalePrice)) ||
       ethers.utils
         .parseEther(displayNewForSalePrice)
-        .lt(requiredBid ?? minForSalePrice));
+        .lt(
+          !requiredBid || interactionState === STATE.PARCEL_RECLAIMING
+            ? minForSalePrice
+            : requiredBid
+        ));
 
   const annualFeePercentage =
     (perSecondFeeNumerator.toNumber() * SECONDS_IN_YEAR * 100) /
@@ -343,9 +348,9 @@ export function ActionForm(props: ActionFormProps) {
               {isForSalePriceInvalid ? (
                 <Form.Control.Feedback type="invalid">
                   For Sale Price must be greater than or equal to{" "}
-                  {requiredBid?.gt(minForSalePrice)
-                    ? truncateEth(ethers.utils.formatEther(requiredBid), 8)
-                    : ethers.utils.formatEther(minForSalePrice)}
+                  {!requiredBid || interactionState === STATE.PARCEL_RECLAIMING
+                    ? ethers.utils.formatEther(minForSalePrice)
+                    : truncateEth(ethers.utils.formatEther(requiredBid), 8)}
                 </Form.Control.Feedback>
               ) : null}
 

--- a/components/cards/AuctionInfo.tsx
+++ b/components/cards/AuctionInfo.tsx
@@ -34,7 +34,6 @@ function AuctionInfo(props: AuctionInfoProps) {
     licenseOwner,
     forSalePrice,
     auctionStart,
-    minForSalePrice,
     interactionState,
     setInteractionState,
     requiredBid,
@@ -90,7 +89,6 @@ function AuctionInfo(props: AuctionInfoProps) {
               forSalePrice,
               BigNumber.from(auctionStart.getTime()).div(1000),
               auctionLength,
-              minForSalePrice
             )
           );
         }, 1000);

--- a/components/cards/ClaimAction.tsx
+++ b/components/cards/ClaimAction.tsx
@@ -20,6 +20,7 @@ export type ClaimActionProps = SidebarProps & {
   setParcelFieldsToUpdate: React.Dispatch<
     React.SetStateAction<ParcelFieldsToUpdate | null>
   >;
+  minForSalePrice: BigNumber;
 };
 
 function ClaimAction(props: ClaimActionProps) {

--- a/components/cards/EditAction.tsx
+++ b/components/cards/EditAction.tsx
@@ -21,6 +21,7 @@ export type EditActionProps = SidebarProps & {
   setParcelFieldsToUpdate: React.Dispatch<
     React.SetStateAction<ParcelFieldsToUpdate | null>
   >;
+  minForSalePrice: BigNumber;
 };
 
 function EditAction(props: EditActionProps) {

--- a/components/cards/ParcelInfo.tsx
+++ b/components/cards/ParcelInfo.tsx
@@ -93,6 +93,7 @@ export type ParcelInfoProps = SidebarProps & {
   setParcelFieldsToUpdate: React.Dispatch<
     React.SetStateAction<ParcelFieldsToUpdate | null>
   >;
+  minForSalePrice: BigNumber;
 };
 
 function ParcelInfo(props: ParcelInfoProps) {

--- a/components/cards/ReclaimAction.tsx
+++ b/components/cards/ReclaimAction.tsx
@@ -20,6 +20,7 @@ export type ReclaimActionProps = SidebarProps & {
   setParcelFieldsToUpdate: React.Dispatch<
     React.SetStateAction<ParcelFieldsToUpdate | null>
   >;
+  minForSalePrice: BigNumber;
 };
 
 function ReclaimAction(props: ReclaimActionProps) {

--- a/components/cards/StreamingInfo.tsx
+++ b/components/cards/StreamingInfo.tsx
@@ -11,7 +11,7 @@ import { sfSubgraph } from "../../redux/store";
 import { NETWORK_ID } from "../../lib/constants";
 import { FlowingBalance } from "../profile/FlowingBalance";
 import { truncateEth } from "../../lib/truncate";
-import { ethers, BigNumber } from "ethers";
+import { ethers } from "ethers";
 import { Framework, NativeAssetSuperToken } from "@superfluid-finance/sdk-core";
 import { STATE, GeoPoint } from "../Map";
 
@@ -31,7 +31,6 @@ type StreamingInfoProps = {
   >;
   isPortfolioToUpdate: boolean;
   setIsPortfolioToUpdate: React.Dispatch<React.SetStateAction<boolean>>;
-  minForSalePrice: BigNumber;
 };
 
 function StreamingInfo(props: StreamingInfoProps) {

--- a/components/profile/Profile.tsx
+++ b/components/profile/Profile.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ethers, BigNumber } from "ethers";
+import { ethers } from "ethers";
 import { CeramicClient } from "@ceramicnetwork/http-client";
 import { Contracts } from "@geo-web/sdk/dist/contract/types";
 import { truncateStr, truncateEth } from "../../lib/truncate";
@@ -35,7 +35,6 @@ type ProfileProps = {
   >;
   isPortfolioToUpdate: boolean;
   setIsPortfolioToUpdate: React.Dispatch<React.SetStateAction<boolean>>;
-  minForSalePrice: BigNumber;
 };
 
 function Profile(props: ProfileProps) {

--- a/components/profile/ProfileModal.tsx
+++ b/components/profile/ProfileModal.tsx
@@ -66,7 +66,6 @@ type ProfileModalProps = {
   isPortfolioToUpdate: boolean;
   setPortfolioNeedActionCount: React.Dispatch<React.SetStateAction<number>>;
   setIsPortfolioToUpdate: React.Dispatch<React.SetStateAction<boolean>>;
-  minForSalePrice: BigNumber;
 };
 
 interface Parcel {
@@ -165,7 +164,6 @@ function ProfileModal(props: ProfileModalProps) {
     setPortfolioParcelCoords,
     isPortfolioToUpdate,
     setIsPortfolioToUpdate,
-    minForSalePrice,
   } = props;
 
   const [ETHBalance, setETHBalance] = useState<string>("");
@@ -360,7 +358,6 @@ function ProfileModal(props: ProfileModalProps) {
                   forSalePrice,
                   BigNumber.from(auctionStart),
                   BigNumber.from(auctionLength),
-                  minForSalePrice
                 );
                 annualFee = BigNumber.from(0);
                 buffer = BigNumber.from(0);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -48,16 +48,14 @@ export function calculateAuctionValue(
   forSalePrice: BigNumber,
   auctionStart: BigNumber,
   auctionLength: BigNumber,
-  minForSalePrice: BigNumber
 ) {
   const blockTimestamp = BigNumber.from(Math.floor(Date.now() / 1000));
   if (blockTimestamp.gt(auctionStart.add(auctionLength))) {
-    return minForSalePrice;
+    return BigNumber.from(0);
   }
 
   const timeElapsed = blockTimestamp.sub(auctionStart);
   const priceDecrease = forSalePrice.mul(timeElapsed).div(auctionLength);
-  const requiredBid = forSalePrice.sub(priceDecrease);
 
-  return requiredBid.lt(minForSalePrice) ? minForSalePrice : requiredBid;
+  return forSalePrice.sub(priceDecrease);
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,7 +15,7 @@ import { getContractsForChainOrThrow } from "@geo-web/sdk";
 import { CeramicClient } from "@ceramicnetwork/http-client";
 import { EthereumAuthProvider } from "@ceramicnetwork/blockchain-utils-linking";
 
-import { ethers, BigNumber } from "ethers";
+import { ethers } from "ethers";
 import { useFirebase } from "../lib/Firebase";
 
 import { Framework, NativeAssetSuperToken } from "@superfluid-finance/sdk-core";
@@ -64,8 +64,6 @@ function IndexPage() {
   const [portfolioParcelCoords, setPortfolioParcelCoords] =
     React.useState<GeoPoint | null>(null);
   const [isPortfolioToUpdate, setIsPortfolioToUpdate] = React.useState(false);
-  const [minForSalePrice, setMinForSalePrice] =
-    React.useState<BigNumber | null>(null);
 
   const { chain } = useNetwork();
   const { address, status } = useAccount();
@@ -195,12 +193,6 @@ function IndexPage() {
         sfFramework.settings.provider
       );
 
-      registryDiamondContract
-        .getMinForSalePrice()
-        .then((_minForSalePrice) => {
-          setMinForSalePrice(_minForSalePrice);
-        });
-
       setRegistryContract(registryDiamondContract);
     }
 
@@ -231,7 +223,6 @@ function IndexPage() {
                   sfFramework &&
                   ceramic &&
                   registryContract &&
-                  minForSalePrice &&
                   paymentToken &&
                   library
                 ) {
@@ -241,7 +232,6 @@ function IndexPage() {
                       sfFramework={sfFramework}
                       ceramic={ceramic}
                       registryContract={registryContract}
-                      minForSalePrice={minForSalePrice}
                       disconnectWallet={disconnectWallet}
                       paymentToken={paymentToken}
                       provider={library}
@@ -313,7 +303,6 @@ function IndexPage() {
       </Container>
       <Container fluid>
         {registryContract &&
-        minForSalePrice &&
         address &&
         library &&
         paymentToken &&
@@ -324,7 +313,6 @@ function IndexPage() {
           <Row>
             <Map
               registryContract={registryContract}
-              minForSalePrice={minForSalePrice}
               account={address.toLowerCase()}
               provider={library}
               ceramic={ceramic}


### PR DESCRIPTION
# Description

For foreclosed parcels allow the required bid to go below the minimum for sale price in the *Dutch Auction Details* and *Max Claim Payment (to Licensor)* cards while allowing the user to only insert a price greater than or equal to the minimum for sale price for the *For Sale Price* input field.

# Issue

fixes #277

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
