### PR TITLE
fix: ignore transaction repriced error

### DIFF
--- a/components/ApproveButton.tsx
+++ b/components/ApproveButton.tsx
@@ -114,17 +114,22 @@ export function ApproveButton(props: ApproveButtonProps) {
       const txn = await op.exec(signer);
       await txn.wait();
     } catch (err) {
-      console.error(err);
-      setErrorMessage(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (err as any).reason
-          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (err as any).reason.replace("execution reverted: ", "")
-          : (err as Error).message
-      );
-      setIsActing(false);
-      setDidFail(true);
-      return false;
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      if (
+        (err as any)?.code !== "TRANSACTION_REPLACED" ||
+        (err as any).cancelled
+      ) {
+        console.error(err);
+        setErrorMessage(
+          (err as any).reason
+            ? (err as any).reason.replace("execution reverted: ", "")
+            : (err as Error).message
+        );
+        setIsActing(false);
+        setDidFail(true);
+        return false;
+      }
+      /* eslint-enable @typescript-eslint/no-explicit-any */
     }
 
     return true;

--- a/components/cards/ActionForm.tsx
+++ b/components/cards/ActionForm.tsx
@@ -159,17 +159,22 @@ export function ActionForm(props: ActionFormProps) {
       // Perform action
       parcelId = await performAction();
     } catch (err) {
-      console.error(err);
-      updateActionData({
-        isActing: false,
-        didFail: true,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        errorMessage: (err as any).reason
-          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (err as any).reason.replace("execution reverted: ", "")
-          : (err as Error).message,
-      });
-      return;
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      if (
+        (err as any)?.code !== "TRANSACTION_REPLACED" ||
+        (err as any).cancelled
+      ) {
+        console.error(err);
+        updateActionData({
+          isActing: false,
+          didFail: true,
+          errorMessage: (err as any).reason
+            ? (err as any).reason.replace("execution reverted: ", "")
+            : (err as Error).message,
+        });
+        return;
+      }
+      /* eslint-enable @typescript-eslint/no-explicit-any */
     }
 
     const content: BasicProfile = {};

--- a/components/cards/OutstandingBidView.tsx
+++ b/components/cards/OutstandingBidView.tsx
@@ -154,17 +154,22 @@ function OutstandingBidView({
         .acceptBid();
       await txn.wait();
     } catch (err) {
-      console.error(err);
-      setErrorMessage(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (err as any).reason
-          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (err as any).reason.replace("execution reverted: ", "")
-          : (err as Error).message
-      );
-      setDidFail(true);
-      setIsActing(false);
-      return;
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      if (
+        (err as any)?.code !== "TRANSACTION_REPLACED" ||
+        (err as any).cancelled
+      ) {
+        console.error(err);
+        setErrorMessage(
+          (err as any).reason
+            ? (err as any).reason.replace("execution reverted: ", "")
+            : (err as Error).message
+        );
+        setDidFail(true);
+        setIsActing(false);
+        return;
+      }
+      /* eslint-enable @typescript-eslint/no-explicit-any */
     }
 
     setIsActing(false);

--- a/components/cards/PlaceBidAction.tsx
+++ b/components/cards/PlaceBidAction.tsx
@@ -158,17 +158,22 @@ function PlaceBidAction(props: PlaceBidActionProps) {
         .placeBid(newNetworkFee, newForSalePrice);
       await txn.wait();
     } catch (err) {
-      console.error(err);
-      setErrorMessage(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (err as any).reason
-          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (err as any).reason.replace("execution reverted: ", "")
-          : (err as Error).message
-      );
-      setDidFail(true);
-      setIsActing(false);
-      return;
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      if (
+        (err as any)?.code !== "TRANSACTION_REPLACED" ||
+        (err as any).cancelled
+      ) {
+        console.error(err);
+        setErrorMessage(
+          (err as any).reason
+            ? (err as any).reason.replace("execution reverted: ", "")
+            : (err as Error).message
+        );
+        setDidFail(true);
+        setIsActing(false);
+        return;
+      }
+      /* eslint-enable @typescript-eslint/no-explicit-any */
     }
 
     setIsActing(false);

--- a/components/cards/RejectBidAction.tsx
+++ b/components/cards/RejectBidAction.tsx
@@ -250,17 +250,22 @@ function RejectBidAction(props: RejectBidActionProps) {
         .rejectBid(newNetworkFee, newForSalePrice);
       await txn.wait();
     } catch (err) {
-      console.error(err);
-      setErrorMessage(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (err as any).reason
-          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (err as any).reason.replace("execution reverted: ", "")
-          : (err as Error).message
-      );
-      setDidFail(true);
-      setIsActing(false);
-      return;
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      if (
+        (err as any)?.code !== "TRANSACTION_REPLACED" ||
+        (err as any).cancelled
+      ) {
+        console.error(err);
+        setErrorMessage(
+          (err as any).reason
+            ? (err as any).reason.replace("execution reverted: ", "")
+            : (err as Error).message
+        );
+        setDidFail(true);
+        setIsActing(false);
+        return;
+      }
+      /* eslint-enable @typescript-eslint/no-explicit-any */
     }
 
     setIsActing(false);


### PR DESCRIPTION
# Description

Ignore the error raised when a transaction is successfully repriced.

# Issue

fixes #281

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Additional comments

When a transaction is repriced Ethers.js raises the `TRANSACTION_REPLACED` error, sets `cancelled` of the error object to `false` and execution after `txn.wait()` continue, in all other cases (like when a transaction is replaced by another unrelated transaction) `error.cancelled` is set to `true` and we error out.

# Alert Reviewers

@codynhat @gravenp
