### PR TITLE
feat: add max claim dimensions line to claim info

### DIFF
--- a/components/cards/ClaimInfo.tsx
+++ b/components/cards/ClaimInfo.tsx
@@ -32,6 +32,7 @@ function ClaimInfo({
         </Card.Text>
         <Card.Text>Single click again to set your parcel shape.</Card.Text>
         <Card.Text>Click and drag the map to pan, if needed.</Card.Text>
+        <Card.Text>Your claim cannot be more than 200 coordinates wide or tall.</Card.Text>
         <Button
           variant="danger"
           className="w-100 mb-2"


### PR DESCRIPTION
# Description

Update the Claim Info window to describe the maximum claim dimensions (200 coordinates tall and/or wide)

# Issue

N/A

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Additional comments

Updating Cadastre to reflect requirements implemented in https://github.com/Geo-Web-Project/core-contracts/pull/105

# Alert Reviewers

@codynhat