### PR TITLE
fix: update media gallery on removed item

### DIFF
--- a/components/gallery/GalleryDisplayGrid.tsx
+++ b/components/gallery/GalleryDisplayGrid.tsx
@@ -12,6 +12,9 @@ export type GalleryDisplayGridProps = GalleryModalProps & {
   setSelectedMediaGalleryItemId: React.Dispatch<
     React.SetStateAction<string | null>
   >;
+  setShouldMediaGalleryUpdate: React.Dispatch<
+    React.SetStateAction<boolean>
+  >;
 };
 
 function GalleryDisplayGrid(props: GalleryDisplayGridProps) {

--- a/components/gallery/GalleryDisplayItem.tsx
+++ b/components/gallery/GalleryDisplayItem.tsx
@@ -29,6 +29,9 @@ export type GalleryDisplayItemProps = GalleryModalProps & {
   setSelectedMediaGalleryItemId: React.Dispatch<
     React.SetStateAction<string | null>
   >;
+  setShouldMediaGalleryUpdate: React.Dispatch<
+    React.SetStateAction<boolean>
+  >;
 };
 
 function GalleryDisplayItem(props: GalleryDisplayItemProps) {
@@ -38,8 +41,7 @@ function GalleryDisplayItem(props: GalleryDisplayItemProps) {
     index,
     selectedMediaGalleryItemId,
     setSelectedMediaGalleryItemId,
-    selectedParcelId,
-    setSelectedParcelId,
+    setShouldMediaGalleryUpdate,
   } = props;
   const [isHovered, setIsHovered] = React.useState(false);
   const [isRemoving, setIsRemoving] = React.useState(false);
@@ -120,12 +122,9 @@ function GalleryDisplayItem(props: GalleryDisplayItemProps) {
     setIsRemoving(true);
     await mediaGalleryItemStreamManager.removeFromMediaGallery();
     if (name) await pinningManager?.unpinCid(name);
-    setIsRemoving(false);
 
-    // Reload parcel
-    const oldParcelId = selectedParcelId;
-    setSelectedParcelId("");
-    setSelectedParcelId(oldParcelId);
+    setShouldMediaGalleryUpdate(true);
+    setIsRemoving(false);
   }
 
   async function retriggerPin() {

--- a/components/gallery/GalleryModal.tsx
+++ b/components/gallery/GalleryModal.tsx
@@ -181,6 +181,7 @@ function GalleryModal(props: GalleryModalProps) {
                 mediaGalleryItems={mediaGalleryItems}
                 selectedMediaGalleryItemId={selectedMediaGalleryItemId}
                 setSelectedMediaGalleryItemId={setSelectedMediaGalleryItemId}
+                setShouldMediaGalleryUpdate={setShouldMediaGalleryUpdate}
                 {...props}
               />
               <a


### PR DESCRIPTION
# Description

When the user remove an item from the media gallery update the grid so that it reflect the change.

# Issue

fixes #295 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
