### PR TITLE
fix: use coordinates without offset for spatial browser query params

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -601,15 +601,15 @@ function Map(props: MapProps) {
   useEffect(() => {
     if (portfolioParcelCenter) {
       flyToLocation({
-        longitude: portfolioParcelCenter.coordinates[0],
-        latitude: portfolioParcelCenter.coordinates[1],
+        longitude: portfolioParcelCenter.coordinates[0] + LON_OFFSET,
+        latitude: portfolioParcelCenter.coordinates[1] + LAT_OFFSET,
         zoom: ZOOM_GRID_LEVEL + 1,
         duration: 500,
       });
 
       setSelectedParcelCoords({
-        x: portfolioParcelCenter.coordinates[0] - LON_OFFSET,
-        y: portfolioParcelCenter.coordinates[1] - LAT_OFFSET,
+        x: portfolioParcelCenter.coordinates[0],
+        y: portfolioParcelCenter.coordinates[1],
       });
     }
   }, [portfolioParcelCenter]);


### PR DESCRIPTION
# Description

For the case of the user jumpimg to a parcel from the portfolio modal remove the offset from the coordinates to be passed as query params to the spatial browser and add it to the ones passed to `flyToLocation()` so that the parcel is centered.

# Issue

fixes #300 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
