### PR TITLE
fix: double the buffer deposit value in ProfileModal

### DIFF
--- a/components/profile/ProfileModal.tsx
+++ b/components/profile/ProfileModal.tsx
@@ -357,7 +357,7 @@ function ProfileModal(props: ProfileModalProps) {
           calculateBufferNeeded(sfFramework, paymentToken, contributionRate)
         )
         .then((bufferNeeded) => {
-          buffer = bufferNeeded;
+          buffer = bufferNeeded.mul(2);
         })
         .then(() => licenseDiamondContract.isPayerBidActive())
         .then((isPayerBidActive) => {


### PR DESCRIPTION
# Description

Double the Buffer Deposit value shown in the ProfileModal's table. 

# Issue

fixes #293 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
