### PR TITLE
fix: use createdAtBlock field for pagination

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -65,6 +65,7 @@ export interface PolygonQuery {
 
 export interface GeoWebParcel {
   id: string;
+  createdAtBlock: number;
   bboxN: number;
   bboxS: number;
   bboxE: number;
@@ -74,17 +75,17 @@ export interface GeoWebParcel {
 
 const query = gql`
   query Polygons(
-    $lastId: BigInt
+    $lastBlock: BigInt
     $north: BigDecimal
     $south: BigDecimal
     $east: BigDecimal
     $west: BigDecimal
   ) {
     geoWebParcels(
-      orderBy: id
+      orderBy: createdAtBlock
       first: 1000
       where: {
-        id_gt: $lastId
+        createdAtBlock_gt: $lastBlock
         bboxN_gt: $south
         bboxS_lt: $north
         bboxE_gt: $west
@@ -92,6 +93,7 @@ const query = gql`
       }
     ) {
       id
+      createdAtBlock
       bboxN
       bboxS
       bboxE
@@ -206,7 +208,7 @@ function Map(props: MapProps) {
   } = props;
   const { data, fetchMore, refetch } = useQuery<PolygonQuery>(query, {
     variables: {
-      lastId: 0,
+      lastBlock: 0,
       north: 0,
       south: 0,
       east: 0,
@@ -325,12 +327,12 @@ function Map(props: MapProps) {
       return;
     }
 
-    let newLastId;
+    let newLastBlock;
 
     if (data.geoWebParcels.length > 0) {
-      newLastId = data.geoWebParcels[data.geoWebParcels.length - 1].id;
+      newLastBlock = data.geoWebParcels[data.geoWebParcels.length - 1].createdAtBlock;
     } else if (newParcel.id) {
-      newLastId = 0;
+      newLastBlock = 0;
     } else {
       return;
     }
@@ -340,7 +342,7 @@ function Map(props: MapProps) {
 
     fetchMore({
       variables: {
-        lastId: newLastId,
+        lastBlock: newLastBlock,
         ...params,
       },
     });
@@ -355,7 +357,7 @@ function Map(props: MapProps) {
     const params = normalizeQueryVariables(mapBounds);
 
     const opts = {
-      lastId: 0,
+      lastBlock: 0,
       ...params,
     };
     refetch(opts);
@@ -382,7 +384,7 @@ function Map(props: MapProps) {
 
     if (nextViewport.zoom >= ZOOM_QUERY_LEVEL && shouldUpdateOnNextZoom) {
       const opts = {
-        lastId: 0,
+        lastBlock: 0,
         ...params,
       };
       refetch(opts);
@@ -401,7 +403,7 @@ function Map(props: MapProps) {
         Math.abs(mapBounds.getCenter().lat - oldCoord.lat) > QUERY_DIM)
     ) {
       const opts = {
-        lastId: 0,
+        lastBlock: 0,
         ...params,
       };
       refetch(opts);

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -3,7 +3,7 @@ export const NETWORK_NAME = "goerli";
 export const PAYMENT_TOKEN = "ETHx";
 export const PAYMENT_TOKEN_FAUCET_URL = "https://faucet.paradigm.xyz";
 export const SUBGRAPH_URL =
-  "https://api.thegraph.com/subgraphs/id/QmTkV9Ho7fyPSsxUnCcjj2npECz2i31NAiijBhGJek8n7D";
+  "https://api.thegraph.com/subgraphs/id/QmaAZpdXw2aXqXEko5Dk3JR5QgGTht3AqgAUTMP7cnjdeZ";
 
 export const CERAMIC_URL = "https://ceramic-clay.geoweb.network/";
 export const CONNECT_NETWORK = "testnet-clay";

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -62,7 +62,7 @@ export function App({ Component, pageProps }: AppProps) {
       typePolicies: {
         Query: {
           fields: {
-            geoWebCoordinates: {
+            geoWebParcels: {
               keyArgs: [],
               merge(existing = [], incoming) {
                 return [...existing, ...incoming];


### PR DESCRIPTION
# Description

Use `createdAtBlock` field of `geoWebParcel` in the subgraph for pagination.

# Issue

fixes #285 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
