### PR TITLE
fix: trigger parcels refetch on move

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -38,7 +38,7 @@ const GRID_DIM = 100;
 export const GW_MAX_LAT = 22;
 export const GW_MAX_LON = 23;
 const ZOOM_QUERY_LEVEL = 8;
-const QUERY_DIM = 1000;
+const QUERY_DIM = 0.025;
 export const LON_OFFSET = 0.00062;
 export const LAT_OFFSET = 0.0001;
 
@@ -259,9 +259,8 @@ function Map(props: MapProps) {
   const [isValidClaim, setIsValidClaim] = React.useState(true);
   const [isParcelAvailable, setIsParcelAvailable] = React.useState(true);
   const [parcelClaimSize, setParcelClaimSize] = React.useState(0);
-  const [interactiveLayerIds, setInteractiveLayerIds] = React.useState<
-    string[]
-  >(["parcels-layer"]);
+  const [interactiveLayerIds, setInteractiveLayerIds] =
+    React.useState<string[]>(["parcels-layer"]);
   const [invalidLicenseId, setInvalidLicenseId] = useState("");
   const [newParcel, setNewParcel] = React.useState<{
     id: string;
@@ -330,7 +329,8 @@ function Map(props: MapProps) {
     let newLastBlock;
 
     if (data.geoWebParcels.length > 0) {
-      newLastBlock = data.geoWebParcels[data.geoWebParcels.length - 1].createdAtBlock;
+      newLastBlock =
+        data.geoWebParcels[data.geoWebParcels.length - 1].createdAtBlock;
     } else if (newParcel.id) {
       newLastBlock = 0;
     } else {


### PR DESCRIPTION
# Description

Change `QUERY_DIM` so that a refetch of parcels is triggered when the user pan around the map.
The value should be low enough to not miss parcels and high enough to avoid redundant refetches.

# Issue

fixes #306 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
