### PR TITLE
fix: use whole screen height for landing page background

### DIFF
--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -96,6 +96,7 @@ function Home({
         left: "0",
         top: "0",
         padding: "16px",
+        minHeight: "100vh",
       }}
     >
       <BetaAgreementModal />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -279,7 +279,7 @@ function IndexPage() {
           variant="dark"
           fixed="top"
           style={{ height: "100px" }}
-          className="d-flex justify-content-space-between border-bottom border-purple border-opacity-25"
+          className="border-bottom border-purple border-opacity-25"
         >
           <Col className="ms-4 ps-3">
             <div


### PR DESCRIPTION
# Description

In the landing page set the height of the container to take at least the whole height available so that the background covers the whole screen on desktop monitors.

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
