### PR TITLE
fix: calculate stream buffer for place bid actions without the existing network fee

### DIFF
--- a/components/cards/PlaceBidAction.tsx
+++ b/components/cards/PlaceBidAction.tsx
@@ -97,12 +97,6 @@ function PlaceBidAction(props: PlaceBidActionProps) {
     (isNaN(Number(displayNewForSalePrice)) ||
       ethers.utils.parseEther(displayNewForSalePrice).lt(currentForSalePrice));
 
-  const existingNetworkFee = fromValueToRate(
-    currentForSalePrice,
-    perSecondFeeNumerator,
-    perSecondFeeDenominator
-  );
-
   const existingAnnualNetworkFee = fromValueToRate(
     currentForSalePrice,
     perSecondFeeNumerator.mul(SECONDS_IN_YEAR),
@@ -304,7 +298,6 @@ function PlaceBidAction(props: PlaceBidActionProps) {
               <TransactionSummaryView
                 existingAnnualNetworkFee={existingAnnualNetworkFee}
                 newAnnualNetworkFee={annualNetworkFeeRate ?? null}
-                existingNetworkFee={existingNetworkFee ?? undefined}
                 newNetworkFee={newNetworkFee}
                 currentForSalePrice={currentForSalePrice}
                 collateralDeposit={newForSalePrice ?? undefined}


### PR DESCRIPTION
# Description

When the user wants to place a bid calculate the *Stream Buffer* based on the full value of the bidder's *For Sale Price* instead of subtracting the `existingNetworkFee` (in `TransactionSummary` component `existingNetworkFee` is initialised to 0 when not passed as a prop by `PlaceBidAction` and nothing is subtracted from `newBuffer` during `streamBuffer` calculation).

# Issue

fixes #321 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
