### PR TITLE
fix: use required bid for price validation in foreclosure auctions

### DIFF
--- a/components/cards/ActionForm.tsx
+++ b/components/cards/ActionForm.tsx
@@ -124,7 +124,9 @@ export function ActionForm(props: ActionFormProps) {
       ethers.utils
         .parseEther(displayNewForSalePrice)
         .lt(
-          !requiredBid || interactionState === STATE.PARCEL_RECLAIMING
+          !requiredBid ||
+            (interactionState === STATE.PARCEL_RECLAIMING &&
+              requiredBid.lt(minForSalePrice))
             ? minForSalePrice
             : requiredBid
         ));
@@ -369,7 +371,9 @@ export function ActionForm(props: ActionFormProps) {
               {isForSalePriceInvalid ? (
                 <Form.Control.Feedback type="invalid">
                   For Sale Price must be greater than or equal to{" "}
-                  {!requiredBid || interactionState === STATE.PARCEL_RECLAIMING
+                  {!requiredBid ||
+                  (interactionState === STATE.PARCEL_RECLAIMING &&
+                    requiredBid.lt(minForSalePrice))
                     ? ethers.utils.formatEther(minForSalePrice)
                     : truncateEth(ethers.utils.formatEther(requiredBid), 8)}
                 </Form.Control.Feedback>


### PR DESCRIPTION
# Description

Use `requiredBid` to validate `displayNewForSalePrice` in reclaim/foreclosure auction contexts unless it is less than `minForSalePrice`.

# Issue

fixes #320 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
