### PR TITLE
fix: set required flow amount to zero if there is no price change in edit actions

### DIFF
--- a/components/cards/ActionForm.tsx
+++ b/components/cards/ActionForm.tsx
@@ -151,7 +151,11 @@ export function ActionForm(props: ActionFormProps) {
         false || parcelWebContentURI.length > 150
     : false;
 
-  const requiredFlowAmount = annualNetworkFeeRate;
+  const requiredFlowAmount =
+    displayCurrentForSalePrice &&
+    displayCurrentForSalePrice === displayNewForSalePrice
+      ? BigNumber.from(0)
+      : annualNetworkFeeRate;
 
   function updateActionData(updatedValues: ActionData) {
     function _updateData(updatedValues: ActionData) {


### PR DESCRIPTION
# Description

Set `requiredFlowAmount` to 0 if during edit actions the user doesn't change the parcel price so that a transaction only for content changes can be submitted without the approval flow.

# Issue

fixes #325 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
