### PR TITLE
fix: catch Ceramic errors in profile modal

### DIFF
--- a/components/profile/ProfileModal.tsx
+++ b/components/profile/ProfileModal.tsx
@@ -391,6 +391,9 @@ function ProfileModal(props: ProfileModalProps) {
         .then((basicProfileStreamId) =>
           basicProfileStreamManager.setExistingStreamId(basicProfileStreamId)
         )
+        .catch((err) => {
+          console.error(`[PARCEL ID: ${parcelId}] ${err.message}`);
+        })
         .then(() => {
           const parcelContent = basicProfileStreamManager.getStreamContent();
           const name =


### PR DESCRIPTION
# Description

Catch Ceramic errors in `ProfileModal` so that the ID of the interested parcel is logged with the error message and a fallback name is used instead of the name that wasn't possible to retrieve.

# Issue

fixes #327

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
