### PR TITLE
feat: switch the order of lat/long in the browser link

### DIFF
--- a/components/cards/ParcelInfo.tsx
+++ b/components/cards/ParcelInfo.tsx
@@ -406,7 +406,7 @@ function ParcelInfo(props: ParcelInfoProps) {
       </>
     );
   } else {
-    const spatialURL = `${SPATIAL_DOMAIN}?longitude=${selectedParcelCoords?.x}&latitude=${selectedParcelCoords?.y}`;
+    const spatialURL = `${SPATIAL_DOMAIN}?latitude=${selectedParcelCoords?.y}&longitude=${selectedParcelCoords?.x}`;
     header = (
       <>
         <div


### PR DESCRIPTION
# Description

Switch the order of the latitude and longitude variables used in the "Open in Spatial Browser" link to follow conventional ordering.

# Issue

N/A

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it

# Alert Reviewers

@codynhat @gravenp
