### PR TITLE
fix: handle parcel content initialization failure

### DIFF
--- a/components/cards/ActionForm.tsx
+++ b/components/cards/ActionForm.tsx
@@ -281,7 +281,9 @@ export function ActionForm(props: ActionFormProps) {
         ownerId,
       });
 
-      setRootCid(root?.basicProfile ? newRootCid.toString() : null);
+      setRootCid(
+        root?.basicProfile || root?.mediaGallery ? newRootCid.toString() : null
+      );
       setShouldParcelContentUpdate(true);
     } else if (licenseId) {
       setSelectedParcelId(`0x${new BN(licenseId.toString()).toString(16)}`);

--- a/components/cards/ActionForm.tsx
+++ b/components/cards/ActionForm.tsx
@@ -276,8 +276,12 @@ export function ActionForm(props: ActionFormProps) {
         parcelId: assetId,
         ownerId,
       });
+      const root = await geoWebContent.raw.getPath("/", {
+        parcelId: assetId,
+        ownerId,
+      });
 
-      setRootCid(newRootCid.toString());
+      setRootCid(root?.basicProfile ? newRootCid.toString() : null);
       setShouldParcelContentUpdate(true);
     } else if (licenseId) {
       setSelectedParcelId(`0x${new BN(licenseId.toString()).toString(16)}`);

--- a/components/cards/ParcelInfo.tsx
+++ b/components/cards/ParcelInfo.tsx
@@ -240,7 +240,9 @@ function ParcelInfo(props: ParcelInfoProps) {
         ownerId,
       });
 
-      setRootCid(root?.basicProfile ? rootCid.toString() : null);
+      setRootCid(
+        root?.basicProfile || root?.mediaGallery ? rootCid.toString() : null
+      );
       setShouldParcelContentUpdate(true);
     })();
   }, [licenseAddress, licenseOwner, selectedParcelId]);

--- a/components/gallery/GalleryForm.tsx
+++ b/components/gallery/GalleryForm.tsx
@@ -216,16 +216,16 @@ function GalleryForm(props: GalleryFormProps) {
         ownerId,
         parcelId: assetId,
       });
+      const rootCid = await geoWebContent.raw.resolveRoot({
+        ownerId,
+        parcelId: assetId,
+      });
       const cidStr = mediaGalleryItem.content;
       const mediaObject: MediaObject = {
         name: mediaGalleryItem.name ?? "",
         content: CID.parse(cidStr ?? ""),
         encodingFormat: mediaGalleryItem.encodingFormat as Encoding,
       };
-      const rootCid = await geoWebContent.raw.resolveRoot({
-        ownerId,
-        parcelId: assetId,
-      });
       const newRoot = await geoWebContent.raw.putPath(
         rootCid,
         selectedMediaGalleryItemIndex !== null

--- a/components/gallery/GalleryModal.tsx
+++ b/components/gallery/GalleryModal.tsx
@@ -26,6 +26,7 @@ function GalleryModal(props: GalleryModalProps) {
     selectedParcelId,
     show,
     setInteractionState,
+    setRootCid,
   } = props;
   const handleClose = () => {
     setInteractionState(STATE.PARCEL_SELECTED);
@@ -35,7 +36,8 @@ function GalleryModal(props: GalleryModalProps) {
     geoWebContent,
     ceramic,
     licenseAddress,
-    selectedParcelId
+    selectedParcelId,
+    setRootCid
   );
 
   const [selectedMediaGalleryItemIndex, setSelectedMediaGalleryItemIndex] =

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@ceramicnetwork/http-client": "^2.11.0",
     "@ceramicnetwork/stream-tile": "^2.10.0",
     "@didtools/pkh-ethereum": "^0.0.1",
+    "@geo-web/content": "^0.3.2",
     "@geo-web/sdk": "^4.2.0",
     "@geo-web/content": "^0.3.2",
     "@geo-web/types": "^0.1.3",


### PR DESCRIPTION
# Description

Check if there was an initialisation failure by checking if the `@geo-web/content` library method `resolveRoot` returns an empty object and if so show a "Not Available" message instead of the Root CID in the parcel info panel.
If there was an initialisation failure the media gallery must be initialised before adding content, this is done in the `useMediaGallery` custom hook.

# Issue

fixes #339 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
