### PR TITLE
feat: show globe view on map load

### DIFF
--- a/.env.testnet
+++ b/.env.testnet
@@ -3,5 +3,5 @@ NEXT_PUBLIC_SUBGRAPH_URL = "https://api.thegraph.com/subgraphs/id/QmVU323tMh9GMw
 NEXT_PUBLIC_CERAMIC_URL = "https://ceramic.geoweb.network/"
 NEXT_PUBLIC_CERAMIC_CONNECT_NETWORK = "mainnet"
 NEXT_PUBLIC_BLOCK_EXPLORER = "https://goerli-optimism.etherscan.io/"
-NEXT_PUBLIC_SPATIAL_DOMAIN = "https://geo-web-browser-testnet.on.fleek.co/"
+NEXT_PUBLIC_SPATIAL_DOMAIN = "https://testnet.geoweb.app/"
 NEXT_PUBLIC_APP_ENV = "testnet"

--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -238,7 +238,7 @@ function Map(props: MapProps) {
   const [viewport, setViewport] = useState<ViewState>({
     latitude: 40.780503,
     longitude: -73.96663,
-    zoom: 13,
+    zoom: 1,
     bearing: 0,
     pitch: 0,
     padding: {
@@ -267,7 +267,7 @@ function Map(props: MapProps) {
   const [isParcelAvailable, setIsParcelAvailable] = React.useState(true);
   const [parcelClaimSize, setParcelClaimSize] = React.useState(0);
   const [interactiveLayerIds, setInteractiveLayerIds] =
-    React.useState<string[]>(["parcels-layer"]);
+    React.useState<string[]>([]);
   const [invalidLicenseId, setInvalidLicenseId] = useState("");
   const [newParcel, setNewParcel] = React.useState<{
     id: string;
@@ -370,6 +370,7 @@ function Map(props: MapProps) {
     refetch(opts);
 
     setOldCoord(mapBounds.getCenter());
+    setInteractiveLayerIds(["parcels-layer"]);
   }
 
   function _onMove(nextViewport: ViewState) {
@@ -384,6 +385,7 @@ function Map(props: MapProps) {
       nextViewport.zoom >= ZOOM_GRID_LEVEL
     ) {
       updateGrid(viewport.latitude, viewport.longitude, grid, setGrid);
+      setInteractiveLayerIds(["parcels-layer", "grid-layer"]);
     }
 
     const mapBounds = mapRef.current.getBounds();
@@ -573,7 +575,6 @@ function Map(props: MapProps) {
         setClaimBase2Coord(null);
         setSelectedParcelId("");
         setParcelHoverId("");
-        setInteractiveLayerIds(["parcels-layer"]);
         break;
       case STATE.PARCEL_SELECTED:
         setClaimBase1Coord(null);
@@ -581,7 +582,6 @@ function Map(props: MapProps) {
         setParcelHoverId(selectedParcelId);
         break;
       case STATE.CLAIM_SELECTING:
-        setInteractiveLayerIds(["parcels-layer", "grid-layer"]);
         break;
       default:
         break;

--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -238,7 +238,7 @@ function Map(props: MapProps) {
   const [viewport, setViewport] = useState<ViewState>({
     latitude: 40.780503,
     longitude: -73.96663,
-    zoom: 1,
+    zoom: process.env.NEXT_PUBLIC_APP_ENV === "mainnet" ? 1 : 13,
     bearing: 0,
     pitch: 0,
     padding: {


### PR DESCRIPTION
# Description

Show a view of the whole earth on map load.

# Issue

fixes #347 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Additional comments
- Set `interactiveLayerIds` after the map loads and the grid is calculated.

# Alert Reviewers

@codynhat @gravenp
