### PR TITLE
fix: do not allow text to wrap around the header

### DIFF
--- a/components/FairLaunchHeader.tsx
+++ b/components/FairLaunchHeader.tsx
@@ -146,7 +146,7 @@ function FairLaunchHeader(props: FairLaunchHeaderProps) {
           }
         >
           <div>
-            <div className="fs-1 text-primary text-center">
+            <div className="fs-1 text-primary text-center text-nowrap">
               {`Current Bid: ${truncateEth(
                 formatBalance(requiredBid),
                 4


### PR DESCRIPTION
# Description

Avoid the text showing the current bid in the fair launch header to wrap around on small screens.

# Issue

fixes #350 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
