### PR TITLE
fix: clear update flag on content retrieval error

### DIFF
--- a/components/cards/ParcelInfo.tsx
+++ b/components/cards/ParcelInfo.tsx
@@ -288,12 +288,6 @@ function ParcelInfo(props: ParcelInfoProps) {
     };
   }, [parcelFieldsToUpdate, selectedParcelId]);
 
-  React.useEffect(() => {
-    if (rootCid) {
-      setShouldParcelContentUpdate(true);
-    }
-  }, [rootCid]);
-
   const isLoading = loading || data == null;
 
   let hrefWebContent;

--- a/components/cards/ParcelInfo.tsx
+++ b/components/cards/ParcelInfo.tsx
@@ -289,8 +289,10 @@ function ParcelInfo(props: ParcelInfoProps) {
   }, [parcelFieldsToUpdate, selectedParcelId]);
 
   React.useEffect(() => {
-    setShouldParcelContentUpdate(true);
-  }, [selectedParcelId]);
+    if (rootCid) {
+      setShouldParcelContentUpdate(true);
+    }
+  }, [rootCid]);
 
   const isLoading = loading || data == null;
 

--- a/lib/geo-web-content/basicProfile.ts
+++ b/lib/geo-web-content/basicProfile.ts
@@ -50,6 +50,7 @@ function useBasicProfile(
         setShouldParcelContentUpdate(false);
       } catch (err) {
         setParcelContent(null);
+        setShouldParcelContentUpdate(false);
         console.error(err);
       }
     })();


### PR DESCRIPTION
# Description

When an update of `parcelContent` fails because there isn't yet a root CID associated with the parcel and owner the update flag is cleared so that we can retry when the root CID is present. 

# Issue

fixes #353 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
