### PR TITLE
perf: Upload DAG branch only on putPath

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -5,3 +5,4 @@ NEXT_PUBLIC_CERAMIC_CONNECT_NETWORK = "mainnet"
 NEXT_PUBLIC_BLOCK_EXPLORER = "https://optimistic.etherscan.io/"
 NEXT_PUBLIC_SPATIAL_DOMAIN = "https://geoweb.app/"
 NEXT_PUBLIC_APP_ENV = "mainnet"
+NEXT_PUBLIC_IPFS_GATEWAY = https://w3s.link

--- a/.env.testnet
+++ b/.env.testnet
@@ -5,3 +5,4 @@ NEXT_PUBLIC_CERAMIC_CONNECT_NETWORK = "mainnet"
 NEXT_PUBLIC_BLOCK_EXPLORER = "https://goerli-optimism.etherscan.io/"
 NEXT_PUBLIC_SPATIAL_DOMAIN = "https://testnet.geoweb.app/"
 NEXT_PUBLIC_APP_ENV = "testnet"
+NEXT_PUBLIC_IPFS_GATEWAY = https://w3s.link

--- a/components/cards/ActionForm.tsx
+++ b/components/cards/ActionForm.tsx
@@ -232,13 +232,13 @@ export function ActionForm(props: ActionFormProps) {
         mediaGallery,
         {
           parentSchema: "ParcelRoot",
+          pin: true,
         }
       );
 
       await geoWebContent.raw.commit(newRoot, {
         ownerId,
         parcelId: assetId,
-        pin: true,
       });
     }
 
@@ -255,13 +255,12 @@ export function ActionForm(props: ActionFormProps) {
           name: content.name ?? "",
           url: content.url ?? "",
         },
-        { parentSchema: "ParcelRoot" }
+        { parentSchema: "ParcelRoot", pin: true }
       );
 
       await geoWebContent.raw.commit(newRoot, {
         ownerId,
         parcelId: assetId,
-        pin: true,
       });
     } catch (err) {
       console.error(err);

--- a/components/gallery/GalleryDisplayItem.tsx
+++ b/components/gallery/GalleryDisplayItem.tsx
@@ -89,12 +89,14 @@ function GalleryDisplayItem(props: GalleryDisplayItemProps) {
       ownerId,
       parcelId: assetId,
     });
-    const newRoot = await geoWebContent.raw.deletePath(rootCid, `/mediaGallery/${index}`)
+    const newRoot = await geoWebContent.raw.deletePath(
+      rootCid,
+      `/mediaGallery/${index}`
+    );
 
     await geoWebContent.raw.commit(newRoot, {
       ownerId,
       parcelId: assetId,
-      pin: true,
     });
 
     const newRootCid = await geoWebContent.raw.resolveRoot({

--- a/components/gallery/GalleryForm.tsx
+++ b/components/gallery/GalleryForm.tsx
@@ -232,13 +232,12 @@ function GalleryForm(props: GalleryFormProps) {
           ? `/mediaGallery/${selectedMediaGalleryItemIndex}`
           : `/mediaGallery/${mediaGallery.length}`,
         mediaObject,
-        { parentSchema: "MediaGallery" }
+        { parentSchema: "MediaGallery", pin: true }
       );
 
       await geoWebContent.raw.commit(newRoot, {
         ownerId,
         parcelId: assetId,
-        pin: true,
       });
       const newRootCid = await geoWebContent.raw.resolveRoot({
         parcelId: assetId,

--- a/lib/geo-web-content/mediaGallery.ts
+++ b/lib/geo-web-content/mediaGallery.ts
@@ -73,13 +73,13 @@ function useMediaGallery(
             mediaGallery,
             {
               parentSchema: "ParcelRoot",
+              pin: true,
             }
           );
 
           await geoWebContent.raw.commit(newRoot, {
             ownerId,
             parcelId: assetId,
-            pin: true,
           });
 
           const newRootCid = await geoWebContent.raw.resolveRoot({

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@ceramicnetwork/http-client": "^2.11.0",
     "@ceramicnetwork/stream-tile": "^2.10.0",
     "@didtools/pkh-ethereum": "^0.0.1",
-    "@geo-web/content": "^0.3.2",
+    "@geo-web/content": "^0.3.6",
     "@geo-web/sdk": "^4.2.0",
     "@geo-web/types": "^0.1.3",
     "@ipld/car": "^4.1.3",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,6 +32,7 @@ import type { IPFS } from "ipfs-core-types";
 import * as IPFSCore from "ipfs-core";
 import { DIDSession } from "did-session";
 import type { Point } from "@turf/turf";
+import * as IPFSHttpClient from "ipfs-http-client";
 
 import { useDisconnect, useAccount, useSigner, useNetwork } from "wagmi";
 import {
@@ -168,11 +169,15 @@ function IndexPage() {
 
       setBeneficiaryAddress(_beneficiaryAddress);
 
-      const _ipfs = await getIpfs({
+      const { ipfs, provider, apiAddress } = await getIpfs({
         providers: [
           httpClient({
-            loadHttpClientModule: () => require("ipfs-http-client"),
+            loadHttpClientModule: () => IPFSHttpClient,
             apiAddress: "/ip4/127.0.0.1/tcp/5001",
+          }),
+          httpClient({
+            loadHttpClientModule: () => IPFSHttpClient,
+            apiAddress: "/ip4/127.0.0.1/tcp/45005",
           }),
           jsIpfs({
             loadJsIpfsModule: () => IPFSCore,
@@ -185,14 +190,14 @@ function IndexPage() {
         ],
       });
 
-      if (_ipfs) {
-        console.log("IPFS API is provided by: " + _ipfs.provider);
-        if (_ipfs.provider === "httpClient") {
-          console.log("HTTP API address: " + _ipfs.apiAddress);
+      if (ipfs) {
+        console.log("IPFS API is provided by: " + provider);
+        if (provider === "httpClient") {
+          console.log("HTTP API address: " + apiAddress);
         }
-
-        setIpfs(_ipfs.ipfs);
       }
+
+      setIpfs(ipfs);
     }
 
     start();
@@ -251,6 +256,7 @@ function IndexPage() {
     const geoWebContent = new GeoWebContent({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ceramic: ceramic as any,
+      ipfsGatewayHost: process.env.NEXT_PUBLIC_IPFS_GATEWAY,
       ipfs,
       web3Storage,
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3236,19 +3236,20 @@
   resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.5.1.tgz#a64d1af3c62e3bb89576ec58af880980a562bf4e"
   integrity sha512-dZMzN0uAjwJXWYYAcnxIwXqRTZw3o14hGe7O6uhwjD1ZQWPVYA5lASgnNskEBra0knVBsOXB4KXg+HnlKewN/A==
 
-"@geo-web/content@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@geo-web/content/-/content-0.3.2.tgz#e39efeb9474538c2d4fb7cb1bf4adf529c8a7e22"
-  integrity sha512-DNUcc0kavlPZ0CuDbtynpOlESNmLW7zGycqAKgF7Fyuz/Bxm2cPbaFv3S3bkOUsrahbUIzSHwqinzQ73ZGbfXQ==
+"@geo-web/content@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@geo-web/content/-/content-0.3.6.tgz#4492f5c39a98b03825f3819ee0a7d2be313ca59a"
+  integrity sha512-45p576D77H3RXWXCPCKmA/8Kkj/LHm5jyKpWtIJvvWXgIZqZhloCQsczBgHMujXGM4C+TnTvRzSVYIe53ibBgw==
   dependencies:
     "@ceramicnetwork/common" "^2.13.0"
     "@ceramicnetwork/http-client" "^2.10.0"
     "@ceramicnetwork/stream-tile" "^2.9.0"
     "@geo-web/types" "^0.1.3"
-    "@ipld/car" "3.2.4"
+    "@ipld/car" "^5.0.1"
     "@ipld/dag-cbor" "^8.0.0"
     "@ipld/schema" "^4.1.2"
     "@typescript-eslint/parser" "^4.33.0"
+    axios "^1.2.1"
     caip "^1.1.0"
     eslint "^7.32.0"
     ipfs-core "0.14.3"
@@ -3674,7 +3675,7 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@ipld/car@3.2.4", "@ipld/car@^3.0.1", "@ipld/car@^3.1.4", "@ipld/car@^3.2.3":
+"@ipld/car@^3.0.1", "@ipld/car@^3.1.4", "@ipld/car@^3.2.3":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/@ipld/car/-/car-3.2.4.tgz#115951ba2255ec51d865773a074e422c169fb01c"
   integrity sha512-rezKd+jk8AsTGOoJKqzfjLJ3WVft7NZNH95f0pfPbicROvzTyvHCNy567HzSUd6gRXZ9im29z5ZEv9Hw49jSYw==
@@ -3701,6 +3702,16 @@
     "@ipld/dag-cbor" "^7.0.0"
     cborg "^1.9.0"
     multiformats "^9.5.4"
+    varint "^6.0.0"
+
+"@ipld/car@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@ipld/car/-/car-5.0.1.tgz#078e8dc81be747dfcf7126c28429b26539d66d15"
+  integrity sha512-YPXr1TztVmTPE4MerjKpFMuIll73MqvEakzWDMqj4uGJnwkY+tE0SlBGmqkMSofOgVMQAxZ6JtuRA93WlTzb8w==
+  dependencies:
+    "@ipld/dag-cbor" "^8.0.0"
+    cborg "^1.9.0"
+    multiformats "^10.0.2"
     varint "^6.0.0"
 
 "@ipld/dag-cbor@^6.0.3":
@@ -9567,6 +9578,15 @@ axios@^0.21.0, axios@^0.21.1:
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
+
+axios@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.2.tgz#72681724c6e6a43a9fea860fc558127dbe32f9f1"
+  integrity sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^2.0.2, axobject-query@^2.2.0:
   version "2.2.0"
@@ -15884,6 +15904,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.12.1, fol
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 for-each@^0.3.3, for-each@~0.3.3:
   version "0.3.3"
@@ -26216,6 +26241,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
# Description

Pins only the new nodes along a branch on `putPath`. Also updates `@geo-web/content` to not download entire CAR on `getPath`.

# Issue

closes #356

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@tnrdd @gravenp
