### PR TITLE
fix: Upload media object content to Web3.storage

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -27,6 +27,7 @@ import "mapbox-gl/dist/mapbox-gl.css";
 import { Framework, NativeAssetSuperToken } from "@superfluid-finance/sdk-core";
 import firebase from "firebase/app";
 import type { IPFS } from "ipfs-core-types";
+import { Web3Storage } from "web3.storage";
 
 import type { Point, MultiPolygon, Polygon } from "@turf/turf";
 import * as turf from "@turf/turf";
@@ -152,6 +153,7 @@ export type MapProps = {
   ceramic: CeramicClient;
   ipfs: IPFS;
   geoWebContent: GeoWebContent;
+  web3Storage: Web3Storage;
   geoWebCoordinate: GeoWebCoordinate;
   firebasePerf: firebase.performance.Performance;
   paymentToken: NativeAssetSuperToken;

--- a/components/gallery/GalleryForm.tsx
+++ b/components/gallery/GalleryForm.tsx
@@ -38,11 +38,11 @@ function GalleryForm(props: GalleryFormProps) {
     licenseAddress,
     selectedParcelId,
     geoWebContent,
+    web3Storage,
     ceramic,
     mediaGalleryItems,
     selectedMediaGalleryItemIndex,
     setSelectedMediaGalleryItemIndex,
-    ipfs,
     setShouldMediaGalleryUpdate,
     setRootCid,
   } = props;
@@ -122,11 +122,11 @@ function GalleryForm(props: GalleryFormProps) {
     const { encoding } = format;
     setFileFormat(encoding ?? null);
 
-    // Add to IPFS
-    const added = await ipfs.add(file);
+    // Upload to Web3 storage
+    const added = await web3Storage.put([file], { wrapWithDirectory: false });
 
     updateMediaGalleryItem({
-      content: added.cid.toString(),
+      content: added,
       encodingFormat: encoding,
     });
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -50,19 +50,16 @@ function getLibrary(provider: any) {
 const { httpClient, jsIpfs } = providers;
 
 function IndexPage() {
-  const [registryContract, setRegistryContract] = React.useState<
-    Contracts["registryDiamondContract"] | null
-  >(null);
+  const [registryContract, setRegistryContract] =
+    React.useState<Contracts["registryDiamondContract"] | null>(null);
   const [ceramic, setCeramic] = React.useState<CeramicClient | null>(null);
   const [ipfs, setIpfs] = React.useState<IPFS | null>(null);
   const [library, setLibrary] = React.useState<ethers.providers.Web3Provider>();
   const { firebasePerf } = useFirebase();
-  const [paymentToken, setPaymentToken] = React.useState<
-    NativeAssetSuperToken | undefined
-  >(undefined);
-  const [sfFramework, setSfFramework] = React.useState<Framework | undefined>(
-    undefined
-  );
+  const [paymentToken, setPaymentToken] =
+    React.useState<NativeAssetSuperToken | undefined>(undefined);
+  const [sfFramework, setSfFramework] =
+    React.useState<Framework | undefined>(undefined);
   const [portfolioNeedActionCount, setPortfolioNeedActionCount] =
     React.useState(0);
   const [selectedParcelId, setSelectedParcelId] = React.useState("");
@@ -86,6 +83,7 @@ function IndexPage() {
     BigNumber.from(0)
   );
   const [isPreFairLaunch, setIsPreFairLaunch] = React.useState<boolean>(false);
+  const [web3Storage, setWeb3Storage] = React.useState<Web3Storage>();
   const [geoWebContent, setGeoWebContent] = React.useState<GeoWebContent>();
   const [geoWebCoordinate, setGeoWebCoordinate] =
     React.useState<GeoWebCoordinate>();
@@ -271,6 +269,7 @@ function IndexPage() {
     });
 
     setGeoWebContent(geoWebContent);
+    setWeb3Storage(web3Storage);
   }, [ceramic, ipfs]);
 
   const Connector = () => {
@@ -419,6 +418,7 @@ function IndexPage() {
               ceramic={ceramic}
               ipfs={ipfs}
               geoWebContent={geoWebContent}
+              web3Storage={web3Storage}
               geoWebCoordinate={geoWebCoordinate}
               firebasePerf={firebasePerf}
               paymentToken={paymentToken}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -407,6 +407,7 @@ function IndexPage() {
         ceramic &&
         ipfs &&
         geoWebContent &&
+        web3Storage &&
         geoWebCoordinate &&
         firebasePerf &&
         sfFramework ? (


### PR DESCRIPTION
# Description

Fixes an issue where actual media gallery item content is not being pinned to Web3.storage.

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Additional comments

`js-geo-web` only pins the DAG, and not the `content` field of a media object. This updates the Cadastre to pin the content separately.

# Alert Reviewers

@tnrdd @gravenp
