### PR TITLE
fix: render a different ParcelInfo for every parcel

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -34,6 +34,7 @@ function Sidebar(props: SidebarProps) {
     interactionState,
     setInteractionState,
     parcelClaimSize,
+    selectedParcelId,
     selectedParcelCoords,
     auctionStart,
     auctionEnd,
@@ -105,6 +106,7 @@ function Sidebar(props: SidebarProps) {
           parcelFieldsToUpdate={parcelFieldsToUpdate}
           setParcelFieldsToUpdate={setParcelFieldsToUpdate}
           licenseAddress={registryContract.address}
+          key={selectedParcelId}
         ></ParcelInfo>
       ) : null}
       {interactionState == STATE.CLAIM_SELECTING ? (

--- a/components/cards/ParcelInfo.tsx
+++ b/components/cards/ParcelInfo.tsx
@@ -417,7 +417,7 @@ function ParcelInfo(props: ParcelInfoProps) {
           <Row>
             <Col className="mx-3" sm="10">
               <h1 style={{ fontSize: "1.5rem", fontWeight: 600 }}>
-                {!data
+                {parcelContent === null
                   ? spinner
                   : parcelContent?.name
                   ? parcelContent.name

--- a/lib/geo-web-content/basicProfile.ts
+++ b/lib/geo-web-content/basicProfile.ts
@@ -49,7 +49,7 @@ function useBasicProfile(
         setParcelContent(_parcelContent);
         setShouldParcelContentUpdate(false);
       } catch (err) {
-        setParcelContent(null);
+        setParcelContent({});
         setShouldParcelContentUpdate(false);
         console.error(err);
       }


### PR DESCRIPTION
# Description

Pass a `key` prop to `ParcelInfo` to tell react to render a different component every time `selectedParcelId` change instead of rerender the same component with different props and same state, otherwise when the user change the selected parcel the custom hook that returns the parcel content is not triggered until the license owner address is fetched from the subgraph, causing the parcel info panel to show stale data until `parcelContent` is updated.

# Issue

fixes #364 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Additional comments

Wait for `useBasicProfile` to return before showing the parcel name to avoid briefly displaying the fallback info instead of the name when a basic profile is present.

# Alert Reviewers

@codynhat @gravenp
