### PR TITLE
feat: specify current spatial browser supported file types in the media gallery modal

### DIFF
--- a/components/gallery/GalleryFileFormat.ts
+++ b/components/gallery/GalleryFileFormat.ts
@@ -11,6 +11,11 @@ const galleryFileFormats: Format[] = [
   { extension: ".usdz", encoding: "model/vnd.usdz+zip", type: "3DModel" },
 ];
 
+const galleryFileFormats3D: Format[] = [
+  { extension: ".glb", encoding: "model/gltf-binary", type: "3DModel" },
+  { extension: ".usdz", encoding: "model/vnd.usdz+zip", type: "3DModel" },
+];
+
 type Format = {
   encoding?: string;
   type?: string;
@@ -38,6 +43,13 @@ const getFormatCS = () => {
   return _formats.toString();
 };
 
+const getFormatCS3D = () => {
+  const _formats = galleryFileFormats3D.map((f) => {
+    return f.extension;
+  });
+  return _formats.toString();
+};
+
 const getFormatType = (encoding: string) => {
   const _type = galleryFileFormats.filter((f) => {
     return f.encoding === encoding;
@@ -45,4 +57,11 @@ const getFormatType = (encoding: string) => {
   return _type[0]["type"];
 };
 
-export { galleryFileFormats, getFormat, getFormatCS, getFormatType };
+export {
+  galleryFileFormats,
+  galleryFileFormats3D,
+  getFormat,
+  getFormatCS,
+  getFormatCS3D,
+  getFormatType,
+};

--- a/components/gallery/GalleryForm.tsx
+++ b/components/gallery/GalleryForm.tsx
@@ -11,9 +11,9 @@ import { AssetId, AccountId } from "caip";
 import { CID } from "multiformats/cid";
 import { GalleryModalProps } from "./GalleryModal";
 import {
-  galleryFileFormats,
+  galleryFileFormats3D,
   getFormat,
-  getFormatCS,
+  getFormatCS3D,
 } from "./GalleryFileFormat";
 import { useFirebase } from "../../lib/Firebase";
 import { NETWORK_ID } from "../../lib/constants";
@@ -282,7 +282,7 @@ function GalleryForm(props: GalleryFormProps) {
                 id="uploadCid"
                 style={{ backgroundColor: "#111320", border: "none" }}
                 className="mt-1"
-                accept={getFormatCS()}
+                accept={getFormatCS3D()}
                 disabled={isUploading || selectedMediaGalleryItemIndex !== null}
                 onChange={captureFile}
                 hidden
@@ -311,7 +311,7 @@ function GalleryForm(props: GalleryFormProps) {
               >
                 <option value="">Select a File Format</option>
 
-                {galleryFileFormats.map((_format, i) => (
+                {galleryFileFormats3D.map((_format, i) => (
                   <option key={i} value={_format.encoding}>
                     {_format.extension} ({_format.encoding})
                   </option>

--- a/components/gallery/GalleryModal.tsx
+++ b/components/gallery/GalleryModal.tsx
@@ -85,8 +85,15 @@ function GalleryModal(props: GalleryModalProps) {
         <>
           <Modal.Body className="bg-dark px-4 text-light">
             <p>
-              Add content to this structured gallery for easy display on the{" "}
-              <a>Geo Web Spatial Browser.</a>
+              The Media Gallery is a simple carousel viewing experience for 3D
+              models on the{" "}
+              <a href="https://geoweb.app" target="_blank" rel="noreferrer">
+                Geo Web alpha spatial browser
+              </a>
+              . Upload .glb and .usdz (iOS only) files here to link them to your
+              parcel (plus pin them on IPFS & back them up on Filecoin). When
+              your parcel is viewed on a compatible smart device, 3D models can
+              also be viewed in AR.
             </p>
             <div className="border border-secondary rounded p-3 text-center">
               <GalleryForm


### PR DESCRIPTION
# Description

Update the text in the gallery modal to specify the file types currently supported by the Geo Web Spatial Browser.
Only allow uploads of .glb and .usdz files but allow already uploaded media objects to be edited even if their content is not a 3D model.

# Issue

fixes #365 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
