### PR TITLE
fix: get required bid and min for sale price separately

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -63,7 +63,9 @@ function Sidebar(props: SidebarProps) {
       });
     registryContract.getMinForSalePrice().then((_minForSalePrice) => {
       setMinForSalePrice(_minForSalePrice);
-      setRequiredBid(_minForSalePrice);
+    });
+    registryContract.requiredBid().then((_requiredBid) => {
+      setRequiredBid(_requiredBid);
     });
   }, [registryContract]);
 


### PR DESCRIPTION
# Description

Separately get `minForSalePrice` and `requiredBid` from the registry contract.

# Issue

fixes #369 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
