### PR TITLE
feat: add validation to wrapping and unwrapping flow

### DIFF
--- a/components/CopyTokenAddress.tsx
+++ b/components/CopyTokenAddress.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import Button from "react-bootstrap/Button";
 import Image from "react-bootstrap/Image";
+import Card from "react-bootstrap/Card";
 import { useSigner } from "wagmi";
 import CopyTooltip from "./CopyTooltip";
 import { truncateStr } from "../lib/truncate";
@@ -34,33 +35,35 @@ export const CopyTokenAddress = ({ options }: { options: TokenOptions }) => {
   }, []);
 
   return (
-    <div className="bg-gray rounded d-flex justify-content-around">
-      <CopyTooltip
-        contentClick="Copied"
-        contentHover="Copy Address"
-        target={
-          <div className="d-flex align-items-center">
-            <Image style={{ width: "16px" }} src="/eth.png" alt="eth" />
-            <span
-              className={`text-black ${
-                options.size === "small" ? "px-1 small" : "px-2"
-              }`}
-            >
-              {truncateStr(options.address, 16)}
-            </span>
-            <Image style={{ width: "16px" }} src="/copy.svg" alt="copy" />
-          </div>
-        }
-        handleCopy={copyAddress}
-      />
-      <Button
-        className={`bg-transparent border-0 ${
-          options.size === "small" ? "px-1" : "px-2"
-        }`}
-        onClick={addToMetaMask}
-      >
-        <Image style={{ width: "16px" }} src="/MetaMask.png" alt="metamask" />
-      </Button>
-    </div>
+    <Card className="bg-gray rounded me-lg-3 me-xl-0">
+      <Card.Body className="d-flex justify-content-around flex-wrap p-0">
+        <CopyTooltip
+          contentClick="Copied"
+          contentHover="Copy Address"
+          target={
+            <div className="d-flex flex-shrink-1 align-items-center">
+              <Image className="me-lg-1 me-xl-0" width={16} src="/eth.png" alt="eth" />
+              <span
+                className={`d-none d-xl-block text-black text-break ${
+                  options.size === "small" ? "px-1 small" : "px-2"
+                }`}
+              >
+                {truncateStr(options.address, 16)}
+              </span>
+              <Image width={16} src="/copy.svg" alt="copy" />
+            </div>
+          }
+          handleCopy={copyAddress}
+        />
+        <Button
+          className={`bg-transparent border-0 ${
+            options.size === "small" ? "px-1" : "px-2"
+          }`}
+          onClick={addToMetaMask}
+        >
+          <Image width={16} src="/MetaMask.png" alt="metamask" />
+        </Button>
+      </Card.Body>
+    </Card>
   );
 };

--- a/components/CopyTooltip.tsx
+++ b/components/CopyTooltip.tsx
@@ -24,7 +24,7 @@ const UpdatingTooltip = forwardRef(function UpdatingTooltip(
   }
 
   return (
-    <Tooltip ref={ref} body {...props}>
+    <Tooltip ref={ref} {...props}>
       {children}
     </Tooltip>
   );

--- a/components/profile/ProfileModal.tsx
+++ b/components/profile/ProfileModal.tsx
@@ -769,7 +769,7 @@ function ProfileModal(props: ProfileModalProps) {
             </Form>
             {!isOutOfBalanceWrap &&
             wrappingAmount !== "" &&
-            Number(ETHBalance) - Number(wrappingAmount) <= 0.001 ? (
+            Number(ETHBalance) - Number(wrappingAmount) < 0.001 ? (
               <span className="d-inline-block text-danger m-0 mt-1 ms-3">
                 Warning: Leave enough ETH for more transactions
               </span>
@@ -833,7 +833,7 @@ function ProfileModal(props: ProfileModalProps) {
             </Form>
             {!isOutOfBalanceUnwrap &&
               unwrappingAmount !== "" &&
-              Number(paymentTokenBalance) - Number(unwrappingAmount) <=
+              Number(paymentTokenBalance) - Number(unwrappingAmount) <
                 0.001 && (
                 <span className="d-inline-block text-danger m-0 mt-1 ms-3">{`Error: ${unwrappingError}`}</span>
               )}

--- a/components/profile/ProfileModal.tsx
+++ b/components/profile/ProfileModal.tsx
@@ -599,10 +599,8 @@ function ProfileModal(props: ProfileModalProps) {
 
     if (action === SuperTokenAction.WRAP) {
       setIsWrapping(false);
-      setWrappingAmount("");
     } else if (action === SuperTokenAction.UNWRAP) {
       setIsUnwrapping(false);
-      setUnwrappingAmount("");
     }
   };
 

--- a/components/profile/ProfileModal.tsx
+++ b/components/profile/ProfileModal.tsx
@@ -768,7 +768,7 @@ function ProfileModal(props: ProfileModalProps) {
               </Button>
             </Form>
             {!isOutOfBalanceWrap &&
-            wrappingAmount &&
+            wrappingAmount !== "" &&
             Number(ETHBalance) - Number(wrappingAmount) <= 0.001 ? (
               <span className="d-inline-block text-danger m-0 mt-1 ms-3">
                 Warning: Leave enough ETH for more transactions
@@ -832,14 +832,11 @@ function ProfileModal(props: ProfileModalProps) {
               </Button>
             </Form>
             {!isOutOfBalanceUnwrap &&
-            unwrappingAmount &&
-            Number(paymentTokenBalance) - Number(unwrappingAmount) <= 0.001 ? (
-              <span className="d-inline-block text-danger m-0 mt-1 ms-3">
-                {`Warning: Leave enough ${PAYMENT_TOKEN} for more transactions`}
-              </span>
-            ) : unwrappingError ? (
-              <span className="d-inline-block text-danger m-0 mt-1 ms-3">{`Error: ${unwrappingError}`}</span>
-            ) : null}
+              unwrappingAmount !== "" &&
+              Number(paymentTokenBalance) - Number(unwrappingAmount) <=
+                0.001 && (
+                <span className="d-inline-block text-danger m-0 mt-1 ms-3">{`Error: ${unwrappingError}`}</span>
+              )}
           </Col>
         </Row>
         <Row className="mt-3 ps-3 fs-1">Portfolio</Row>

--- a/components/profile/ProfileModal.tsx
+++ b/components/profile/ProfileModal.tsx
@@ -753,7 +753,10 @@ function ProfileModal(props: ProfileModalProps) {
                 placeholder="0.00"
                 size="sm"
                 value={wrappingAmount}
-                onChange={(e) => setWrappingAmount(e.target.value)}
+                onChange={(e) => {
+                  setWrappingAmount(e.target.value);
+                  setWrappingError("");
+                }}
               />
               <Button
                 variant={isOutOfBalanceWrap ? "info" : "secondary"}
@@ -769,14 +772,14 @@ function ProfileModal(props: ProfileModalProps) {
                   : "Wrap"}
               </Button>
             </Form>
-            {!isOutOfBalanceWrap &&
-            wrappingAmount !== "" &&
-            Number(ETHBalance) - Number(wrappingAmount) < 0.001 ? (
+            {wrappingError ? (
+              <span className="d-inline-block text-danger m-0 mt-1 ms-3">{`Error: ${wrappingError}`}</span>
+            ) : !isOutOfBalanceWrap &&
+              wrappingAmount !== "" &&
+              Number(ETHBalance) - Number(wrappingAmount) < 0.001 ? (
               <span className="d-inline-block text-danger m-0 mt-1 ms-3">
                 Warning: Leave enough ETH for more transactions
               </span>
-            ) : wrappingError ? (
-              <span className="d-inline-block text-danger m-0 mt-1 ms-3">{`Error: ${wrappingError}`}</span>
             ) : null}
           </Col>
           <Col
@@ -817,7 +820,10 @@ function ProfileModal(props: ProfileModalProps) {
                 placeholder="0.00"
                 size="sm"
                 value={unwrappingAmount}
-                onChange={(e) => setUnwrappingAmount(e.target.value)}
+                onChange={(e) => {
+                  setUnwrappingAmount(e.target.value);
+                  setUnwrappingError("");
+                }}
               />
               <Button
                 variant={isOutOfBalanceUnwrap ? "info" : "primary"}

--- a/components/profile/ProfileModal.tsx
+++ b/components/profile/ProfileModal.tsx
@@ -680,6 +680,10 @@ function ProfileModal(props: ProfileModalProps) {
       keyboard={false}
       centered
       onHide={handleCloseProfile}
+      onExit={() => {
+        setWrappingError("");
+        setUnwrappingError("");
+      }}
       size="xl"
       contentClassName="bg-dark"
     >

--- a/components/profile/ProfileModal.tsx
+++ b/components/profile/ProfileModal.tsx
@@ -831,12 +831,9 @@ function ProfileModal(props: ProfileModalProps) {
                   : "Unwrap"}
               </Button>
             </Form>
-            {!isOutOfBalanceUnwrap &&
-              unwrappingAmount !== "" &&
-              Number(paymentTokenBalance) - Number(unwrappingAmount) <
-                0.001 && (
-                <span className="d-inline-block text-danger m-0 mt-1 ms-3">{`Error: ${unwrappingError}`}</span>
-              )}
+            {unwrappingError && (
+              <span className="d-inline-block text-danger m-0 mt-1 ms-3">{`Error: ${unwrappingError}`}</span>
+            )}
           </Col>
         </Row>
         <Row className="mt-3 ps-3 fs-1">Portfolio</Row>

--- a/components/profile/ProfileModal.tsx
+++ b/components/profile/ProfileModal.tsx
@@ -37,6 +37,7 @@ import {
   SECONDS_IN_YEAR,
 } from "../../lib/constants";
 import { getETHBalance } from "../../lib/getBalance";
+import { useSuperTokenBalance } from "../../lib/superTokenBalance";
 import { truncateStr, truncateEth } from "../../lib/truncate";
 import { calculateBufferNeeded, calculateAuctionValue } from "../../lib/utils";
 import { STATE } from "../Map";
@@ -189,6 +190,10 @@ function ProfileModal(props: ProfileModalProps) {
   } = props;
 
   const [ETHBalance, setETHBalance] = useState<string>("");
+  const [wrappingAmount, setWrappingAmount] = useState<string>("");
+  const [unwrappingAmount, setUnwrappingAmount] = useState<string>("");
+  const [wrappingError, setWrappingError] = useState<string>("");
+  const [unwrappingError, setUnwrappingError] = useState<string>("");
   const [isWrapping, setIsWrapping] = useState<boolean>(false);
   const [isUnWrapping, setIsUnwrapping] = useState<boolean>(false);
   const [portfolio, setPortfolio] = useState<PortfolioParcel[]>([]);
@@ -203,6 +208,20 @@ function ProfileModal(props: ProfileModalProps) {
     },
   });
 
+  const { superTokenBalance } = useSuperTokenBalance(
+    account,
+    paymentToken.address
+  );
+
+  const paymentTokenBalance = ethers.utils.formatEther(superTokenBalance);
+  const isOutOfBalanceWrap =
+    wrappingAmount !== "" &&
+    ETHBalance !== "" &&
+    Number(wrappingAmount) > Number(ETHBalance);
+  const isOutOfBalanceUnwrap =
+    unwrappingAmount !== "" &&
+    paymentTokenBalance !== "" &&
+    Number(unwrappingAmount) > Number(paymentTokenBalance);
   useEffect(() => {
     let isMounted = true;
 
@@ -518,25 +537,25 @@ function ProfileModal(props: ProfileModalProps) {
   ): Promise<void> => {
     let txn: ethers.providers.TransactionResponse | null = null;
 
-    if (action === SuperTokenAction.WRAP) {
-      txn = await paymentToken
-        .upgrade({
-          amount: ethers.utils.parseEther(amount).toString(),
-        })
-        .exec(provider.getSigner());
-
-      setIsWrapping(true);
-    } else if (action === SuperTokenAction.UNWRAP) {
-      txn = await paymentToken
-        .downgrade({
-          amount: ethers.utils.parseEther(amount).toString(),
-        })
-        .exec(provider.getSigner());
-
-      setIsUnwrapping(true);
-    }
-
     try {
+      if (action === SuperTokenAction.WRAP) {
+        txn = await paymentToken
+          .upgrade({
+            amount: ethers.utils.parseEther(amount).toString(),
+          })
+          .exec(provider.getSigner());
+
+        setIsWrapping(true);
+      } else if (action === SuperTokenAction.UNWRAP) {
+        txn = await paymentToken
+          .downgrade({
+            amount: ethers.utils.parseEther(amount).toString(),
+          })
+          .exec(provider.getSigner());
+
+        setIsUnwrapping(true);
+      }
+
       if (txn === null) {
         return;
       }
@@ -549,28 +568,54 @@ function ProfileModal(props: ProfileModalProps) {
       );
 
       setETHBalance(ethBalance);
-    } catch (error) {
-      console.error(error);
+
+      if (action === SuperTokenAction.WRAP) {
+        setWrappingAmount("");
+        setWrappingError("");
+      } else {
+        setUnwrappingAmount("");
+        setUnwrappingError("");
+      }
+    } catch (err) {
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      if (
+        (err as any)?.code !== "TRANSACTION_REPLACED" ||
+        (err as any).cancelled
+      ) {
+        const message = (err as any).reason
+          ? (err as any).reason
+              .replace("execution reverted: ", "")
+              .replace(/([^.])$/, "$1.")
+          : (err as Error).message;
+        if (action === SuperTokenAction.WRAP) {
+          setWrappingError(message);
+        } else {
+          setUnwrappingError(message);
+        }
+        console.error(err);
+      }
+      /* eslint-enable @typescript-eslint/no-explicit-any */
     }
 
     if (action === SuperTokenAction.WRAP) {
       setIsWrapping(false);
+      setWrappingAmount("");
     } else if (action === SuperTokenAction.UNWRAP) {
       setIsUnwrapping(false);
+      setUnwrappingAmount("");
     }
   };
 
-  const handleOnSubmit = async (
+  const handleSubmit = async (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     e: any,
+    amount: string,
     action: SuperTokenAction
   ): Promise<void> => {
     e.preventDefault();
-    const amount = e.target[0].value;
 
-    if (!Number.isNaN(amount) && amount > 0) {
+    if (!Number.isNaN(amount) && Number(amount) > 0) {
       await executeSuperTokenTransaction(amount, action);
-      e.target.reset();
     }
   };
 
@@ -684,35 +729,53 @@ function ProfileModal(props: ProfileModalProps) {
               : "Your ETHx balance is 0. Any Geo Web parcels you previously licensed have been put in foreclosure."}
           </Col>
         </Row>
-        <Row className="mt-3">
+        <Row className="mt-3 align-items-start">
           <Col className="p-3 ms-3 fs-6 border border-purple rounded" sm="3">
-            <span style={{ marginLeft: "15px" }}>{`ETH: ${ETHBalance}`}</span>
+            <span style={{ marginLeft: "15px" }}>{`ETH: ${truncateEth(
+              ETHBalance,
+              8
+            )}`}</span>
             <Form
               id="wrapForm"
-              className="form-inline"
+              className="form-inline mt-5 ms-3 me-3"
               noValidate
-              onSubmit={(e) => handleOnSubmit(e, SuperTokenAction.WRAP)}
-              style={{ marginTop: "46px", marginLeft: "15px", width: "218px" }}
+              onSubmit={(e) =>
+                handleSubmit(e, wrappingAmount, SuperTokenAction.WRAP)
+              }
             >
               <Form.Control
                 required
                 autoFocus
                 type="text"
                 className="mb-2"
-                id="amount"
                 placeholder="0.00"
                 size="sm"
+                value={wrappingAmount}
+                onChange={(e) => setWrappingAmount(e.target.value)}
               />
               <Button
-                variant="secondary"
+                variant={isOutOfBalanceWrap ? "info" : "secondary"}
                 type="submit"
-                disabled={isWrapping}
+                disabled={isWrapping || isOutOfBalanceWrap}
                 size="sm"
                 className="w-100"
               >
-                {isWrapping ? "Wrapping..." : "Wrap"}
+                {isWrapping
+                  ? "Wrapping..."
+                  : isOutOfBalanceWrap
+                  ? "Insufficient ETH"
+                  : "Wrap"}
               </Button>
             </Form>
+            {!isOutOfBalanceWrap &&
+            wrappingAmount &&
+            Number(ETHBalance) - Number(wrappingAmount) <= 0.001 ? (
+              <span className="d-inline-block text-danger m-0 mt-1 ms-3">
+                Warning: Leave enough ETH for more transactions
+              </span>
+            ) : wrappingError ? (
+              <span className="d-inline-block text-danger m-0 mt-1 ms-3">{`Error: ${wrappingError}`}</span>
+            ) : null}
           </Col>
           <Col
             sm="1"
@@ -724,7 +787,7 @@ function ProfileModal(props: ProfileModalProps) {
             <div style={{ marginLeft: "15px" }}>
               {`${PAYMENT_TOKEN}: `}
               <FlowingBalance
-                format={(x) => ethers.utils.formatUnits(x)}
+                format={(x) => truncateEth(ethers.utils.formatUnits(x), 8)}
                 accountTokenSnapshot={accountTokenSnapshot}
               />
             </div>
@@ -739,8 +802,10 @@ function ProfileModal(props: ProfileModalProps) {
             </div>
             <Form
               noValidate
-              onSubmit={(e) => handleOnSubmit(e, SuperTokenAction.UNWRAP)}
-              style={{ width: "220px", marginLeft: "15px" }}
+              onSubmit={(e) =>
+                handleSubmit(e, unwrappingAmount, SuperTokenAction.UNWRAP)
+              }
+              className="form-inline ms-3 me-3"
             >
               <Form.Control
                 required
@@ -749,17 +814,32 @@ function ProfileModal(props: ProfileModalProps) {
                 className="mb-2"
                 placeholder="0.00"
                 size="sm"
+                value={unwrappingAmount}
+                onChange={(e) => setUnwrappingAmount(e.target.value)}
               />
               <Button
-                variant="primary"
+                variant={isOutOfBalanceUnwrap ? "info" : "primary"}
                 type="submit"
-                disabled={isUnWrapping}
+                disabled={isUnWrapping || isOutOfBalanceUnwrap}
                 size="sm"
-                className="w-100"
+                className="w-100 text-break"
               >
-                {isWrapping ? "Unwrapping..." : "Unwrap"}
+                {isUnWrapping
+                  ? "Unwrapping..."
+                  : isOutOfBalanceUnwrap
+                  ? `Insufficient ${PAYMENT_TOKEN}`
+                  : "Unwrap"}
               </Button>
             </Form>
+            {!isOutOfBalanceUnwrap &&
+            unwrappingAmount &&
+            Number(paymentTokenBalance) - Number(unwrappingAmount) <= 0.001 ? (
+              <span className="d-inline-block text-danger m-0 mt-1 ms-3">
+                {`Warning: Leave enough ${PAYMENT_TOKEN} for more transactions`}
+              </span>
+            ) : unwrappingError ? (
+              <span className="d-inline-block text-danger m-0 mt-1 ms-3">{`Error: ${unwrappingError}`}</span>
+            ) : null}
           </Col>
         </Row>
         <Row className="mt-3 ps-3 fs-1">Portfolio</Row>

--- a/components/wrap/WrapModal.tsx
+++ b/components/wrap/WrapModal.tsx
@@ -210,7 +210,7 @@ function WrapModal({
           </Button>
         </form>
         {!isOutOfBalance &&
-        amount &&
+        amount !== "" &&
         Number(ETHBalance) - Number(amount) <= 0.001 ? (
           <span className="d-inline-block w-100 px-1 me-0 text-danger">
             Warning: Leave enough ETH for more transactions

--- a/components/wrap/WrapModal.tsx
+++ b/components/wrap/WrapModal.tsx
@@ -194,7 +194,10 @@ function WrapModal({
             }}
             placeholder="0.00"
             value={amount}
-            onChange={(e) => setAmount(e.target.value)}
+            onChange={(e) => {
+              setAmount(e.target.value);
+              setError("");
+            }}
           />
           <Button
             type="submit"
@@ -209,14 +212,14 @@ function WrapModal({
               : `Wrap ETH to ${PAYMENT_TOKEN}`}
           </Button>
         </form>
-        {!isOutOfBalance &&
-        amount !== "" &&
-        Number(ETHBalance) - Number(amount) < 0.001 ? (
+        {error ? (
+          <span className="d-inline-block w-100 px-1 me-0 text-danger">{`Error: ${error}`}</span>
+        ) : !isOutOfBalance &&
+          amount !== "" &&
+          Number(ETHBalance) - Number(amount) < 0.001 ? (
           <span className="d-inline-block w-100 px-1 me-0 text-danger">
             Warning: Leave enough ETH for more transactions
           </span>
-        ) : error ? (
-          <span className="d-inline-block w-100 px-1 me-0 text-danger">{`Error: ${error}`}</span>
         ) : null}
       </Modal.Footer>
     </Modal>

--- a/components/wrap/WrapModal.tsx
+++ b/components/wrap/WrapModal.tsx
@@ -211,7 +211,7 @@ function WrapModal({
         </form>
         {!isOutOfBalance &&
         amount !== "" &&
-        Number(ETHBalance) - Number(amount) <= 0.001 ? (
+        Number(ETHBalance) - Number(amount) < 0.001 ? (
           <span className="d-inline-block w-100 px-1 me-0 text-danger">
             Warning: Leave enough ETH for more transactions
           </span>

--- a/components/wrap/WrapModal.tsx
+++ b/components/wrap/WrapModal.tsx
@@ -80,6 +80,7 @@ function WrapModal({
       const ethBalance = await getETHBalance(provider, account);
       // Update balances
       setETHBalance(ethBalance);
+      setAmount("");
       setError("");
     } catch (err) {
       /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -111,7 +112,6 @@ function WrapModal({
         console.log("amount is valid", amount);
         (async () => {
           await wrapETH(amount);
-          setAmount("");
         })();
       }
     }


### PR DESCRIPTION
# Description

Add validation to `WrapModal` and the two wrap and unwrap forms in `ProfileModal`.
- Disable the submit button if the user is out of balance.
- Show a warning message if the amount of ETH that would remain after a wrapping transaction is less than 0.001 ETH.
- Show an error message if there is some error during the transaction.
- Truncate the wallet balances in the `ProfileModal` to 8 digits.
- Make the elements more responsive to smaller screen sizes.

# Issue

fixes #370 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
