### PR TITLE
fix: set root cid inside basic profile custom hook

### DIFF
--- a/components/cards/ActionForm.tsx
+++ b/components/cards/ActionForm.tsx
@@ -42,7 +42,6 @@ export type ActionFormProps = SidebarProps & {
   flowOperator: string | null;
   minForSalePrice: BigNumber;
   setShouldParcelContentUpdate?: React.Dispatch<React.SetStateAction<boolean>>;
-  setRootCid?: React.Dispatch<React.SetStateAction<string | null>>;
 };
 
 export type ActionData = {
@@ -81,7 +80,6 @@ export function ActionForm(props: ActionFormProps) {
     minForSalePrice,
     paymentToken,
     setShouldParcelContentUpdate,
-    setRootCid,
   } = props;
 
   const {
@@ -268,19 +266,7 @@ export function ActionForm(props: ActionFormProps) {
 
     updateActionData({ isActing: false });
 
-    if (setShouldParcelContentUpdate && setRootCid) {
-      const newRootCid = await geoWebContent.raw.resolveRoot({
-        parcelId: assetId,
-        ownerId,
-      });
-      const root = await geoWebContent.raw.getPath("/", {
-        parcelId: assetId,
-        ownerId,
-      });
-
-      setRootCid(
-        root?.basicProfile || root?.mediaGallery ? newRootCid.toString() : null
-      );
+    if (setShouldParcelContentUpdate) {
       setShouldParcelContentUpdate(true);
     } else if (licenseId) {
       setSelectedParcelId(`0x${new BN(licenseId.toString()).toString(16)}`);

--- a/components/cards/ParcelInfo.tsx
+++ b/components/cards/ParcelInfo.tsx
@@ -6,7 +6,6 @@ import Button from "react-bootstrap/Button";
 import Spinner from "react-bootstrap/Spinner";
 import {
   PAYMENT_TOKEN,
-  NETWORK_ID,
   BLOCK_EXPLORER,
   SPATIAL_DOMAIN,
 } from "../../lib/constants";
@@ -29,7 +28,6 @@ import PlaceBidAction from "./PlaceBidAction";
 import RejectBidAction from "./RejectBidAction";
 import AuctionInfo from "./AuctionInfo";
 import { useBasicProfile } from "../../lib/geo-web-content/basicProfile";
-import { AssetId, AccountId } from "caip";
 import BN from "bn.js";
 import { GeoWebContent } from "@geo-web/content";
 import { PCOLicenseDiamondFactory } from "@geo-web/sdk/dist/contract/index";
@@ -119,7 +117,6 @@ function ParcelInfo(props: ParcelInfoProps) {
     },
   });
 
-  const [rootCid, setRootCid] = React.useState<string | null>("");
   const [requiredBid, setRequiredBid] = React.useState<BigNumber | null>(null);
   const [auctionStartTimestamp, setAuctionStartTimestamp] =
     React.useState<Date | null>(null);
@@ -129,12 +126,13 @@ function ParcelInfo(props: ParcelInfoProps) {
     null
   );
 
-  const { parcelContent, setShouldParcelContentUpdate } = useBasicProfile(
-    geoWebContent,
-    licenseAddress,
-    data?.geoWebParcel?.licenseOwner,
-    selectedParcelId
-  );
+  const { parcelContent, rootCid, setRootCid, setShouldParcelContentUpdate } =
+    useBasicProfile(
+      geoWebContent,
+      licenseAddress,
+      data?.geoWebParcel?.licenseOwner,
+      selectedParcelId
+    );
 
   const spinner = (
     <Spinner as="span" size="sm" animation="border" role="status">
@@ -225,43 +223,6 @@ function ParcelInfo(props: ParcelInfoProps) {
 
     loadLicenseDiamond();
   }, [licenseDiamondAddress, sfFramework, paymentToken]);
-
-  React.useEffect(() => {
-    if (!licenseAddress || !licenseOwner || !selectedParcelId) {
-      return;
-    }
-
-    (async () => {
-      setRootCid("");
-
-      const assetId = new AssetId({
-        chainId: `eip155:${NETWORK_ID}`,
-        assetName: {
-          namespace: "erc721",
-          reference: registryContract.address.toLowerCase(),
-        },
-        tokenId: new BN(selectedParcelId.slice(2), "hex").toString(10),
-      });
-      const ownerId = new AccountId({
-        chainId: `eip155:${NETWORK_ID}`,
-        address: licenseOwner,
-      });
-
-      const rootCid = await geoWebContent.raw.resolveRoot({
-        parcelId: assetId,
-        ownerId,
-      });
-      const root = await geoWebContent.raw.getPath("/", {
-        parcelId: assetId,
-        ownerId,
-      });
-
-      setRootCid(
-        root?.basicProfile || root?.mediaGallery ? rootCid.toString() : null
-      );
-      setShouldParcelContentUpdate(true);
-    })();
-  }, [licenseAddress, licenseOwner, selectedParcelId]);
 
   React.useEffect(() => {
     if (data?.geoWebParcel && parcelFieldsToUpdate && queryTimerId) {

--- a/components/cards/ParcelInfo.tsx
+++ b/components/cards/ParcelInfo.tsx
@@ -496,7 +496,7 @@ function ParcelInfo(props: ParcelInfoProps) {
               </p>
               <p className="text-truncate">
                 <span className="fw-bold">Root CID: </span>{" "}
-                {rootCid === null ? (
+                {rootCid === "" ? (
                   "Not Available"
                 ) : !rootCid ? (
                   spinner

--- a/lib/geo-web-content/basicProfile.ts
+++ b/lib/geo-web-content/basicProfile.ts
@@ -12,7 +12,7 @@ function useBasicProfile(
   parcelId?: string
 ) {
   const [parcelContent, setParcelContent] = useState<BasicProfile | null>(null);
-  const [rootCid, setRootCid] = useState<string | null>("");
+  const [rootCid, setRootCid] = useState<string | null>(null);
   const [shouldParcelContentUpdate, setShouldParcelContentUpdate] =
     useState<boolean>(true);
 
@@ -29,6 +29,9 @@ function useBasicProfile(
           return;
         }
 
+        setParcelContent(null);
+        setRootCid(null);
+
         const assetId = new AssetId({
           chainId: `eip155:${NETWORK_ID}`,
           assetName: {
@@ -42,27 +45,27 @@ function useBasicProfile(
           chainId: `eip155:${NETWORK_ID}`,
           address: licenseOwner,
         });
-        const _parcelContent = await geoWebContent.raw.getPath(
-          "/basicProfile",
-          { parcelId: assetId, ownerId }
-        );
         const _rootCid = await geoWebContent.raw.resolveRoot({
           parcelId: assetId,
           ownerId,
         });
-        const root = await geoWebContent.raw.getPath("/", {
-          parcelId: assetId,
-          ownerId,
+        const _parcelContent = await geoWebContent.raw.get(
+          _rootCid,
+          "/basicProfile",
+          { schema: "BasicProfile" }
+        );
+        const root = await geoWebContent.raw.get(_rootCid, "/", {
+          schema: "ParcelRoot",
         });
 
         setParcelContent(_parcelContent);
         setRootCid(
-          root?.basicProfile || root?.mediaGallery ? _rootCid.toString() : null
+          root?.basicProfile || root?.mediaGallery ? _rootCid.toString() : ""
         );
         setShouldParcelContentUpdate(false);
       } catch (err) {
         setParcelContent({});
-        setRootCid(null);
+        setRootCid("");
         setShouldParcelContentUpdate(false);
         console.error(err);
       }

--- a/lib/geo-web-content/basicProfile.ts
+++ b/lib/geo-web-content/basicProfile.ts
@@ -12,6 +12,7 @@ function useBasicProfile(
   parcelId?: string
 ) {
   const [parcelContent, setParcelContent] = useState<BasicProfile | null>(null);
+  const [rootCid, setRootCid] = useState<string | null>("");
   const [shouldParcelContentUpdate, setShouldParcelContentUpdate] =
     useState<boolean>(true);
 
@@ -45,11 +46,23 @@ function useBasicProfile(
           "/basicProfile",
           { parcelId: assetId, ownerId }
         );
+        const _rootCid = await geoWebContent.raw.resolveRoot({
+          parcelId: assetId,
+          ownerId,
+        });
+        const root = await geoWebContent.raw.getPath("/", {
+          parcelId: assetId,
+          ownerId,
+        });
 
         setParcelContent(_parcelContent);
+        setRootCid(
+          root?.basicProfile || root?.mediaGallery ? _rootCid.toString() : null
+        );
         setShouldParcelContentUpdate(false);
       } catch (err) {
         setParcelContent({});
+        setRootCid(null);
         setShouldParcelContentUpdate(false);
         console.error(err);
       }
@@ -62,7 +75,7 @@ function useBasicProfile(
     shouldParcelContentUpdate,
   ]);
 
-  return { parcelContent, setShouldParcelContentUpdate };
+  return { parcelContent, rootCid, setRootCid, setShouldParcelContentUpdate };
 }
 
 export { useBasicProfile };


### PR DESCRIPTION
# Description

Set the root CID inside the custom hook used to get `parcelContent` instead of the effect hook in `ParceInfo`, so that both the basic profile info and the root CID are showed at the same time in the UI.

# Issue

fixes #382 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
