### PR TITLE
fix: show loading spinner while updating the gallery

### DIFF
--- a/components/gallery/GalleryDisplayGrid.tsx
+++ b/components/gallery/GalleryDisplayGrid.tsx
@@ -8,6 +8,7 @@ import { GalleryModalProps } from "./GalleryModal";
 export type GalleryDisplayGridProps = GalleryModalProps & {
   mediaGalleryItems: MediaObject[];
   selectedMediaGalleryItemIndex: number | null;
+  shouldMediaGalleryUpdate: boolean;
   setSelectedMediaGalleryItemIndex: React.Dispatch<
     React.SetStateAction<number | null>
   >;
@@ -20,7 +21,6 @@ function GalleryDisplayGrid(props: GalleryDisplayGridProps) {
   const {
     mediaGalleryItems,
     selectedMediaGalleryItemIndex,
-    setSelectedMediaGalleryItemIndex,
   } = props;
 
   return (
@@ -32,7 +32,6 @@ function GalleryDisplayGrid(props: GalleryDisplayGridProps) {
             mediaGalleryItem={mediaGalleryItem}
             index={i}
             selectedMediaGalleryItemIndex={selectedMediaGalleryItemIndex}
-            setSelectedMediaGalleryItemIndex={setSelectedMediaGalleryItemIndex}
           />
         </Col>
       ))}

--- a/components/gallery/GalleryDisplayItem.tsx
+++ b/components/gallery/GalleryDisplayItem.tsx
@@ -22,6 +22,7 @@ export type GalleryDisplayItemProps = GalleryModalProps & {
   mediaGalleryItem: MediaObject;
   index: number;
   selectedMediaGalleryItemIndex: number | null;
+  shouldMediaGalleryUpdate: boolean;
   setSelectedMediaGalleryItemIndex: React.Dispatch<
     React.SetStateAction<number | null>
   >;
@@ -38,6 +39,7 @@ function GalleryDisplayItem(props: GalleryDisplayItemProps) {
     selectedParcelId,
     index,
     selectedMediaGalleryItemIndex,
+    shouldMediaGalleryUpdate,
     setSelectedMediaGalleryItemIndex,
     setShouldMediaGalleryUpdate,
     setRootCid,
@@ -67,7 +69,13 @@ function GalleryDisplayItem(props: GalleryDisplayItemProps) {
     );
   }
 
-  const removeMediaGalleryItem = React.useCallback(async () => {
+  React.useEffect(() => {
+    if (isRemoving && !shouldMediaGalleryUpdate) {
+      setIsRemoving(false);
+    }
+  }, [shouldMediaGalleryUpdate]);
+
+  async function removeMediaGalleryItem() {
     if (!geoWebContent) {
       return;
     }
@@ -109,8 +117,7 @@ function GalleryDisplayItem(props: GalleryDisplayItemProps) {
 
     setRootCid(newRootCid.toString());
     setShouldMediaGalleryUpdate(true);
-    setIsRemoving(false);
-  }, [geoWebContent, index]);
+  }
 
   function handleEdit() {
     setSelectedMediaGalleryItemIndex(index);

--- a/components/gallery/GalleryForm.tsx
+++ b/components/gallery/GalleryForm.tsx
@@ -27,6 +27,7 @@ interface MediaGalleryItem {
 export type GalleryFormProps = GalleryModalProps & {
   mediaGalleryItems: MediaObject[];
   selectedMediaGalleryItemIndex: number | null;
+  shouldMediaGalleryUpdate: boolean;
   setSelectedMediaGalleryItemIndex: React.Dispatch<
     React.SetStateAction<number | null>
   >;
@@ -42,18 +43,20 @@ function GalleryForm(props: GalleryFormProps) {
     ceramic,
     mediaGalleryItems,
     selectedMediaGalleryItemIndex,
+    shouldMediaGalleryUpdate,
     setSelectedMediaGalleryItemIndex,
     setShouldMediaGalleryUpdate,
     setRootCid,
   } = props;
+
   const [detectedFileFormat, setDetectedFileFormat] = React.useState(null);
   const [fileFormat, setFileFormat] = React.useState<string | null>(null);
   const [isUploading, setIsUploading] = React.useState(false);
   const [isSaving, setIsSaving] = React.useState(false);
   const [didFail, setDidFail] = React.useState(false);
-
   const [mediaGalleryItem, setMediaGalleryItem] =
     React.useState<MediaGalleryItem>({});
+
   const { firebasePerf } = useFirebase();
 
   React.useEffect(() => {
@@ -72,6 +75,13 @@ function GalleryForm(props: GalleryFormProps) {
         mediaGalleryItems[selectedMediaGalleryItemIndex].encodingFormat,
     });
   }, [selectedMediaGalleryItemIndex]);
+
+  React.useEffect(() => {
+    if (isSaving && !shouldMediaGalleryUpdate) {
+      setIsSaving(false);
+      setSelectedMediaGalleryItemIndex(null);
+    }
+  }, [shouldMediaGalleryUpdate]);
 
   function updateMediaGalleryItem(updatedValues: MediaGalleryItem) {
     function _updateData(updatedValues: MediaGalleryItem) {
@@ -142,8 +152,6 @@ function GalleryForm(props: GalleryFormProps) {
     setMediaGalleryItem({});
     // setPinningService("buckets");
     setDidFail(false);
-
-    setSelectedMediaGalleryItemIndex(null);
   }
 
   async function addToGallery() {
@@ -163,7 +171,6 @@ function GalleryForm(props: GalleryFormProps) {
     trace?.stop();
 
     setShouldMediaGalleryUpdate(true);
-    setIsSaving(false);
   }
 
   async function saveChanges() {
@@ -172,8 +179,6 @@ function GalleryForm(props: GalleryFormProps) {
     await commitNewRoot(mediaGalleryItem);
     clearForm();
 
-    setIsSaving(false);
-    setSelectedMediaGalleryItemIndex(null);
     setShouldMediaGalleryUpdate(true);
   }
 
@@ -196,58 +201,55 @@ function GalleryForm(props: GalleryFormProps) {
     // setPinningServiceAccessToken("");
   }
 
-  const commitNewRoot = React.useCallback(
-    async (mediaGalleryItem: MediaGalleryItem) => {
-      if (!geoWebContent) {
-        return;
-      }
-      const assetId = new AssetId({
-        chainId: `eip155:${NETWORK_ID}`,
-        assetName: {
-          namespace: "erc721",
-          reference: licenseAddress.toLowerCase(),
-        },
-        tokenId: new BN(selectedParcelId.slice(2), "hex").toString(10),
-      });
-      const ownerId = new AccountId(
-        AccountId.parse(ceramic.did?.parent.split("did:pkh:")[1] ?? "")
-      );
-      const mediaGallery = await geoWebContent.raw.getPath("/mediaGallery", {
-        ownerId,
-        parcelId: assetId,
-      });
-      const rootCid = await geoWebContent.raw.resolveRoot({
-        ownerId,
-        parcelId: assetId,
-      });
-      const cidStr = mediaGalleryItem.content;
-      const mediaObject: MediaObject = {
-        name: mediaGalleryItem.name ?? "",
-        content: CID.parse(cidStr ?? ""),
-        encodingFormat: mediaGalleryItem.encodingFormat as Encoding,
-      };
-      const newRoot = await geoWebContent.raw.putPath(
-        rootCid,
-        selectedMediaGalleryItemIndex !== null
-          ? `/mediaGallery/${selectedMediaGalleryItemIndex}`
-          : `/mediaGallery/${mediaGallery.length}`,
-        mediaObject,
-        { parentSchema: "MediaGallery", pin: true }
-      );
+  async function commitNewRoot(mediaGalleryItem: MediaGalleryItem) {
+    if (!geoWebContent) {
+      return;
+    }
+    const assetId = new AssetId({
+      chainId: `eip155:${NETWORK_ID}`,
+      assetName: {
+        namespace: "erc721",
+        reference: licenseAddress.toLowerCase(),
+      },
+      tokenId: new BN(selectedParcelId.slice(2), "hex").toString(10),
+    });
+    const ownerId = new AccountId(
+      AccountId.parse(ceramic.did?.parent.split("did:pkh:")[1] ?? "")
+    );
+    const mediaGallery = await geoWebContent.raw.getPath("/mediaGallery", {
+      ownerId,
+      parcelId: assetId,
+    });
+    const rootCid = await geoWebContent.raw.resolveRoot({
+      ownerId,
+      parcelId: assetId,
+    });
+    const cidStr = mediaGalleryItem.content;
+    const mediaObject: MediaObject = {
+      name: mediaGalleryItem.name ?? "",
+      content: CID.parse(cidStr ?? ""),
+      encodingFormat: mediaGalleryItem.encodingFormat as Encoding,
+    };
+    const newRoot = await geoWebContent.raw.putPath(
+      rootCid,
+      selectedMediaGalleryItemIndex !== null
+        ? `/mediaGallery/${selectedMediaGalleryItemIndex}`
+        : `/mediaGallery/${mediaGallery.length}`,
+      mediaObject,
+      { parentSchema: "MediaGallery", pin: true }
+    );
 
-      await geoWebContent.raw.commit(newRoot, {
-        ownerId,
-        parcelId: assetId,
-      });
-      const newRootCid = await geoWebContent.raw.resolveRoot({
-        parcelId: assetId,
-        ownerId,
-      });
+    await geoWebContent.raw.commit(newRoot, {
+      ownerId,
+      parcelId: assetId,
+    });
+    const newRootCid = await geoWebContent.raw.resolveRoot({
+      parcelId: assetId,
+      ownerId,
+    });
 
-      setRootCid(newRootCid.toString());
-    },
-    [geoWebContent, selectedMediaGalleryItemIndex]
-  );
+    setRootCid(newRootCid.toString());
+  }
 
   const isReadyToAdd =
     mediaGalleryItem.content && mediaGalleryItem.name && !isSaving;
@@ -353,7 +355,7 @@ function GalleryForm(props: GalleryFormProps) {
         </Row>
         <Row className="px-3 text-end">
           <Col xs="auto" lg={{ offset: 6 }} className="mb-3">
-            <Button variant="danger" onClick={clearForm}>
+            <Button variant="danger" disabled={isSaving} onClick={clearForm}>
               Cancel
             </Button>
           </Col>

--- a/components/gallery/GalleryModal.tsx
+++ b/components/gallery/GalleryModal.tsx
@@ -32,7 +32,11 @@ function GalleryModal(props: GalleryModalProps) {
     setInteractionState(STATE.PARCEL_SELECTED);
   };
 
-  const { mediaGalleryItems, setShouldMediaGalleryUpdate } = useMediaGallery(
+  const {
+    mediaGalleryItems,
+    shouldMediaGalleryUpdate,
+    setShouldMediaGalleryUpdate,
+  } = useMediaGallery(
     geoWebContent,
     ceramic,
     licenseAddress,
@@ -102,6 +106,7 @@ function GalleryModal(props: GalleryModalProps) {
                 setSelectedMediaGalleryItemIndex={
                   setSelectedMediaGalleryItemIndex
                 }
+                shouldMediaGalleryUpdate={shouldMediaGalleryUpdate}
                 setShouldMediaGalleryUpdate={setShouldMediaGalleryUpdate}
                 {...props}
               />
@@ -111,6 +116,7 @@ function GalleryModal(props: GalleryModalProps) {
                 setSelectedMediaGalleryItemIndex={
                   setSelectedMediaGalleryItemIndex
                 }
+                shouldMediaGalleryUpdate={shouldMediaGalleryUpdate}
                 setShouldMediaGalleryUpdate={setShouldMediaGalleryUpdate}
                 {...props}
               />

--- a/lib/geo-web-content/mediaGallery.ts
+++ b/lib/geo-web-content/mediaGallery.ts
@@ -13,8 +13,9 @@ function useMediaGallery(
   parcelId: string,
   setRootCid: React.Dispatch<React.SetStateAction<string | null>>
 ) {
-  const [mediaGalleryItems, setMediaGalleryItems] =
-    useState<MediaObject[] | null>(null);
+  const [mediaGalleryItems, setMediaGalleryItems] = useState<
+    MediaObject[] | null
+  >(null);
   const [shouldMediaGalleryUpdate, setShouldMediaGalleryUpdate] =
     useState<boolean>(true);
 
@@ -99,7 +100,11 @@ function useMediaGallery(
     })();
   }, [parcelId, shouldMediaGalleryUpdate]);
 
-  return { mediaGalleryItems, setShouldMediaGalleryUpdate };
+  return {
+    mediaGalleryItems,
+    shouldMediaGalleryUpdate,
+    setShouldMediaGalleryUpdate,
+  };
 }
 
 export { useMediaGallery };


### PR DESCRIPTION
# Description

Show a loading spinner on uploads, edits and deletes in the media gallery until it is fully updated.

# Issue

fixes #383 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
