### PR TITLE
fix: Remove using cookies on delegation

### DIFF
--- a/components/ConnectWallet.tsx
+++ b/components/ConnectWallet.tsx
@@ -106,6 +106,7 @@ export default function ConnectWallet(props: ConnectWalletProps) {
     const w3Client = await createW3UpClient();
     let sessionKey = ssxConnection.builder.jwk();
 
+    let ssxSession: SSXClientSession;
     try {
       // Login to SSX
       sessionKey = ssxConnection.builder.jwk();
@@ -113,7 +114,7 @@ export default function ConnectWallet(props: ConnectWalletProps) {
         return Promise.reject(new Error("unable to retrieve session key"));
       }
       /* eslint-disable @typescript-eslint/no-non-null-assertion */
-      const ssxSession: SSXClientSession = {
+      ssxSession = {
         address: address!,
         walletAddress: await signer!.getAddress(),
         chainId: chain!.id,
@@ -134,6 +135,11 @@ export default function ConnectWallet(props: ConnectWalletProps) {
           url: "/storage/delegation",
           responseType: "blob",
           data: {
+            siwe: ssxSession!.siwe,
+            signature: ssxSession!.signature,
+            daoLogin: false,
+            resolveEns: false,
+            resolveLens: false,
             aud: w3Client.agent().did(),
           },
         });
@@ -156,7 +162,7 @@ export default function ConnectWallet(props: ConnectWalletProps) {
         await w3Client.addProof(delegation);
       } catch (err) {
         localStorage.removeItem("didsession");
-        initSession();
+        // initSession();
         return;
       }
     }


### PR DESCRIPTION
# Description

Removes using cookies from SSX for better reliability and Safari support. The SIWE message is now set directly on `/delegation`

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@tnrdd
