### PR TITLE
fix: ensure correct info is shown during state transition

### DIFF
--- a/components/ApproveButton.tsx
+++ b/components/ApproveButton.tsx
@@ -14,6 +14,7 @@ export type ApproveButtonProps = OffCanvasPanelProps & {
   spender: string | null;
   flowOperator: string | null;
   setErrorMessage: (v: string) => void;
+  isActing: boolean;
   setIsActing: (v: boolean) => void;
   setDidFail: (v: boolean) => void;
   isAllowed: boolean;
@@ -41,6 +42,7 @@ export function ApproveButton(props: ApproveButtonProps) {
     requiredFlowAmount,
     flowOperator,
     setErrorMessage,
+    isActing,
     setIsActing,
     setDidFail,
     isAllowed,
@@ -229,10 +231,14 @@ export function ApproveButton(props: ApproveButtonProps) {
       className="w-100 mb-3"
       onClick={() => submit()}
       disabled={
-        isDisabled || !isReady || isAllowed || totalActions > completedActions
+        isDisabled ||
+        !isReady ||
+        isAllowed ||
+        isActing ||
+        totalActions > completedActions
       }
     >
-      {isAllowed ? (
+      {isAllowed || isActing ? (
         <>
           <span className="ms-4">{PAYMENT_TOKEN} use allowed</span>
           <Image src="./task-done.svg" className="float-end"></Image>

--- a/components/ApproveButton.tsx
+++ b/components/ApproveButton.tsx
@@ -227,7 +227,7 @@ export function ApproveButton(props: ApproveButtonProps) {
 
   return (
     <Button
-      variant={isAllowed ? "info" : "primary"}
+      variant={isAllowed || isActing ? "info" : "primary"}
       className="w-100 mb-3"
       onClick={() => submit()}
       disabled={

--- a/components/cards/ActionForm.tsx
+++ b/components/cards/ActionForm.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../lib/constants";
 import BN from "bn.js";
 import { AssetId } from "caip";
-import { OffCanvasPanelProps } from "../OffCanvasPanel";
+import { OffCanvasPanelProps, ParcelFieldsToUpdate } from "../OffCanvasPanel";
 import InfoTooltip from "../InfoTooltip";
 import { truncateEth } from "../../lib/truncate";
 import { STATE } from "../Map";
@@ -43,6 +43,9 @@ export type ActionFormProps = OffCanvasPanelProps & {
   flowOperator: string | null;
   minForSalePrice: BigNumber;
   setShouldParcelContentUpdate?: React.Dispatch<React.SetStateAction<boolean>>;
+  setParcelFieldsToUpdate: React.Dispatch<
+    React.SetStateAction<ParcelFieldsToUpdate | null>
+  >;
 };
 
 export type ActionData = {
@@ -81,6 +84,7 @@ export function ActionForm(props: ActionFormProps) {
     minForSalePrice,
     paymentToken,
     setShouldParcelContentUpdate,
+    setParcelFieldsToUpdate,
   } = props;
 
   const {
@@ -192,15 +196,6 @@ export function ActionForm(props: ActionFormProps) {
       /* eslint-enable @typescript-eslint/no-explicit-any */
     }
 
-    if (setShouldParcelContentUpdate) {
-      setShouldParcelContentUpdate(true);
-    } else if (licenseId) {
-      setSelectedParcelId(`0x${new BN(licenseId.toString()).toString(16)}`);
-    }
-
-    setInteractionState(STATE.PARCEL_SELECTED);
-    setShouldRefetchParcelsData(true);
-
     const content: BasicProfile = {};
     if (parcelName) {
       content["name"] = parcelName;
@@ -222,35 +217,35 @@ export function ActionForm(props: ActionFormProps) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const ownerDID = ceramic.did!.parent;
 
-    if (
-      licenseId &&
-      (interactionState === STATE.CLAIM_SELECTED ||
-        (interactionState === STATE.PARCEL_RECLAIMING &&
-          account !== licenseOwner))
-    ) {
-      await geoWebContent.raw.initRoot({ parcelId: assetId, ownerDID });
-      const rootCid = await geoWebContent.raw.resolveRoot({
-        parcelId: assetId,
-        ownerDID,
-      });
-      const mediaGallery: MediaGallery = [];
-      const newRoot = await geoWebContent.raw.putPath(
-        rootCid,
-        "/mediaGallery",
-        mediaGallery,
-        {
-          parentSchema: "ParcelRoot",
-          pin: true,
-        }
-      );
-
-      await geoWebContent.raw.commit(newRoot, {
-        ownerDID,
-        parcelId: assetId,
-      });
-    }
-
     try {
+      if (
+        licenseId &&
+        (interactionState === STATE.CLAIM_SELECTED ||
+          (interactionState === STATE.PARCEL_RECLAIMING &&
+            account !== licenseOwner))
+      ) {
+        await geoWebContent.raw.initRoot({ parcelId: assetId, ownerDID });
+        const rootCid = await geoWebContent.raw.resolveRoot({
+          parcelId: assetId,
+          ownerDID,
+        });
+        const mediaGallery: MediaGallery = [];
+        const newRoot = await geoWebContent.raw.putPath(
+          rootCid,
+          "/mediaGallery",
+          mediaGallery,
+          {
+            parentSchema: "ParcelRoot",
+            pin: true,
+          }
+        );
+
+        await geoWebContent.raw.commit(newRoot, {
+          ownerDID,
+          parcelId: assetId,
+        });
+      }
+
       const rootCid = await geoWebContent.raw.resolveRoot({
         parcelId: assetId,
         ownerDID,
@@ -280,6 +275,19 @@ export function ActionForm(props: ActionFormProps) {
     }
 
     updateActionData({ isActing: false });
+
+    if (setShouldParcelContentUpdate) {
+      setShouldParcelContentUpdate(true);
+    } else if (licenseId) {
+      setSelectedParcelId(`0x${new BN(licenseId.toString()).toString(16)}`);
+    }
+
+    setInteractionState(STATE.PARCEL_SELECTED);
+    setShouldRefetchParcelsData(true);
+    setParcelFieldsToUpdate({
+      forSalePrice: !displayNewForSalePrice || displayNewForSalePrice !== displayCurrentForSalePrice,
+      licenseOwner: !licenseOwner || licenseOwner !== account,
+    });
   }
 
   const isInvalid = isForSalePriceInvalid || !displayNewForSalePrice;

--- a/components/cards/ActionForm.tsx
+++ b/components/cards/ActionForm.tsx
@@ -192,6 +192,15 @@ export function ActionForm(props: ActionFormProps) {
       /* eslint-enable @typescript-eslint/no-explicit-any */
     }
 
+    if (setShouldParcelContentUpdate) {
+      setShouldParcelContentUpdate(true);
+    } else if (licenseId) {
+      setSelectedParcelId(`0x${new BN(licenseId.toString()).toString(16)}`);
+    }
+
+    setInteractionState(STATE.PARCEL_SELECTED);
+    setShouldRefetchParcelsData(true);
+
     const content: BasicProfile = {};
     if (parcelName) {
       content["name"] = parcelName;
@@ -271,15 +280,6 @@ export function ActionForm(props: ActionFormProps) {
     }
 
     updateActionData({ isActing: false });
-
-    if (setShouldParcelContentUpdate) {
-      setShouldParcelContentUpdate(true);
-    } else if (licenseId) {
-      setSelectedParcelId(`0x${new BN(licenseId.toString()).toString(16)}`);
-    }
-
-    setInteractionState(STATE.PARCEL_SELECTED);
-    setShouldRefetchParcelsData(true);
   }
 
   const isInvalid = isForSalePriceInvalid || !displayNewForSalePrice;
@@ -488,6 +488,7 @@ export function ActionForm(props: ActionFormProps) {
               setErrorMessage={(v) => {
                 updateActionData({ errorMessage: v });
               }}
+              isActing={isActing ?? false}
               setIsActing={(v) => {
                 updateActionData({ isActing: v });
               }}

--- a/components/cards/ClaimAction.tsx
+++ b/components/cards/ClaimAction.tsx
@@ -32,7 +32,6 @@ function ClaimAction(props: ClaimActionProps) {
     perSecondFeeDenominator,
     requiredBid,
     setNewParcel,
-    setParcelFieldsToUpdate,
     sfFramework,
     paymentToken,
     minForSalePrice,
@@ -128,8 +127,6 @@ function ClaimAction(props: ClaimActionProps) {
     setNewParcel((prev) => {
       return { ...prev, id: `0x${new BN(licenseId.toString()).toString(16)}` };
     });
-
-    setParcelFieldsToUpdate({ forSalePrice: true, licenseOwner: true });
 
     return licenseId;
   }

--- a/components/cards/EditAction.tsx
+++ b/components/cards/EditAction.tsx
@@ -17,6 +17,7 @@ export type EditActionProps = ParcelInfoProps & {
   perSecondFeeNumerator: BigNumber;
   perSecondFeeDenominator: BigNumber;
   hasOutstandingBid: boolean;
+  licenseOwner: string;
   parcelData: GeoWebParcel;
   licenseDiamondContract: IPCOLicenseDiamond | null;
   setParcelFieldsToUpdate: React.Dispatch<
@@ -38,7 +39,6 @@ function EditAction(props: EditActionProps) {
     licenseDiamondContract,
     sfFramework,
     paymentToken,
-    setParcelFieldsToUpdate,
   } = props;
 
   const displayCurrentForSalePrice = formatBalance(
@@ -197,8 +197,6 @@ function EditAction(props: EditActionProps) {
       .connect(signer)
       .editBid(newNetworkFee, ethers.utils.parseEther(displayNewForSalePrice));
     await txn.wait();
-
-    setParcelFieldsToUpdate({ forSalePrice: true, licenseOwner: false });
   }
 
   return (

--- a/components/cards/OutstandingBidView.tsx
+++ b/components/cards/OutstandingBidView.tsx
@@ -43,11 +43,9 @@ function OutstandingBidView(props: OutstandingBidViewProps) {
     licensorIsOwner,
     registryContract,
     licenseDiamondContract,
-    selectedParcelId,
     perSecondFeeNumerator,
     perSecondFeeDenominator,
     setInteractionState,
-    setSelectedParcelId,
     setShouldRefetchParcelsData,
     setParcelFieldsToUpdate,
     sfFramework,
@@ -216,12 +214,13 @@ function OutstandingBidView(props: OutstandingBidViewProps) {
       return;
     }
 
+    setParcelFieldsToUpdate({
+      forSalePrice: false,
+      licenseOwner: true,
+    });
     setIsActing(false);
     setInteractionState(STATE.PARCEL_SELECTED);
-
-    setSelectedParcelId("");
     setShouldRefetchParcelsData(true);
-    setSelectedParcelId(selectedParcelId);
   }
 
   // Calculate payout if surplus or depleted balance

--- a/components/cards/ParcelInfo.tsx
+++ b/components/cards/ParcelInfo.tsx
@@ -618,7 +618,8 @@ function ParcelInfo(props: ParcelInfoProps) {
           {interactionState == STATE.PARCEL_EDITING &&
           account &&
           signer &&
-          data?.geoWebParcel ? (
+          data?.geoWebParcel &&
+          licenseOwner ? (
             <EditAction
               {...props}
               signer={signer}
@@ -628,6 +629,7 @@ function ParcelInfo(props: ParcelInfoProps) {
                 !parcelFieldsToUpdate ? hasOutstandingBid : false
               }
               licenseDiamondContract={licenseDiamondContract}
+              licenseOwner={licenseOwner}
               setShouldParcelContentUpdate={setShouldParcelContentUpdate}
               setRootCid={setRootCid}
             />

--- a/components/cards/PlaceBidAction.tsx
+++ b/components/cards/PlaceBidAction.tsx
@@ -339,6 +339,7 @@ function PlaceBidAction(props: PlaceBidActionProps) {
               requiredFlowPermissions={1}
               flowOperator={licenseDiamondContract?.address ?? null}
               setErrorMessage={setErrorMessage}
+              isActing={isActing}
               setIsActing={setIsActing}
               setDidFail={setDidFail}
               isAllowed={isAllowed}

--- a/components/cards/ReclaimAction.tsx
+++ b/components/cards/ReclaimAction.tsx
@@ -39,7 +39,6 @@ function ReclaimAction(props: ReclaimActionProps) {
     selectedParcelId,
     sfFramework,
     paymentToken,
-    setParcelFieldsToUpdate,
     parcelContent,
   } = props;
 
@@ -153,11 +152,6 @@ function ReclaimAction(props: ReclaimActionProps) {
     }
 
     await txn.wait();
-
-    setParcelFieldsToUpdate({
-      forSalePrice: true,
-      licenseOwner: !isOwner,
-    });
 
     return new BN(selectedParcelId.split("x")[1], 16).toString(10);
   }

--- a/components/cards/RejectBidAction.tsx
+++ b/components/cards/RejectBidAction.tsx
@@ -443,6 +443,7 @@ function RejectBidAction(props: RejectBidActionProps) {
               requiredFlowPermissions={2}
               flowOperator={licenseDiamondContract?.address ?? null}
               setErrorMessage={setErrorMessage}
+              isActing={isActing}
               setIsActing={setIsActing}
               setDidFail={setDidFail}
               isAllowed={isAllowed}


### PR DESCRIPTION
# Description

- Update *For Sale Price* and *License Owner* fields on successful parcel transfer so that the the UI shows the correct info before we switch state.
- Update the *License Owner* field after the IPFS content on claim, edit and reclaim transactions to avoid the UI showing wrong info for a bit.
- While a transaction is being confirmed keep the approve button in its latest state (ETHx use allowed).

# Issue

fixes #421 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
