### PR TITLE
feat: use only ID for URL based parcel navigation

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -1,7 +1,7 @@
 import { gql, useQuery } from "@apollo/client";
 import * as React from "react";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Col from "react-bootstrap/Col";
 import ReactMapGL, {
   AttributionControl,
@@ -13,7 +13,6 @@ import {
   MapLayerTouchEvent,
   LngLatBounds,
   LngLat,
-  PaddingOptions,
 } from "mapbox-gl";
 import OffCanvasPanel from "./OffCanvasPanel";
 import ClaimSource from "./sources/ClaimSource";
@@ -44,7 +43,7 @@ import { Framework, NativeAssetSuperToken } from "@superfluid-finance/sdk-core";
 import firebase from "firebase/app";
 import type { IPFS } from "ipfs-core-types";
 
-import type { Point, MultiPolygon, Polygon } from "@turf/turf";
+import type { MultiPolygon, Polygon } from "@turf/turf";
 import * as turf from "@turf/turf";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -52,6 +51,7 @@ import * as turf from "@turf/turf";
 import type { InvocationConfig } from "@web3-storage/upload-client";
 import ParcelList from "./parcels/ParcelList";
 import { useMediaQuery } from "../lib/mediaQuery";
+import { useParcelNavigation } from "../lib/parcelNavigation";
 
 export const ZOOM_GRID_LEVEL = 17;
 const GRID_DIM_LAT = 140;
@@ -186,8 +186,6 @@ export type MapProps = {
   paymentToken: NativeAssetSuperToken;
   sfFramework: Framework;
   setPortfolioNeedActionCount: React.Dispatch<React.SetStateAction<number>>;
-  parcelNavigationCenter: Point | null;
-  setParcelNavigationCenter: React.Dispatch<React.SetStateAction<Point | null>>;
   shouldRefetchParcelsData: boolean;
   auctionStart: BigNumber;
   auctionEnd: BigNumber;
@@ -215,7 +213,6 @@ function Map(props: MapProps) {
     setSelectedParcelId,
     interactionState,
     setInteractionState,
-    parcelNavigationCenter,
   } = props;
   const { data, fetchMore, refetch } = useQuery<PolygonQuery>(query, {
     variables: {
@@ -287,9 +284,6 @@ function Map(props: MapProps) {
   const [claimBase1Coord, setClaimBase1Coord] = useState<Coord | null>(null);
   const [claimBase2Coord, setClaimBase2Coord] = useState<Coord | null>(null);
 
-  const [selectedParcelCoords, setSelectedParcelCoords] =
-    useState<Coord | null>(null);
-
   const [existingMultiPoly, setExistingMultiPoly] = useState<
     MultiPolygon | Polygon
   >(turf.multiPolygon([]).geometry);
@@ -313,6 +307,11 @@ function Map(props: MapProps) {
 
   const { isMobile, isTablet } = useMediaQuery();
   const router = useRouter();
+  const { getParcelCoords, flyToParcel } = useParcelNavigation(
+    !router.query.id || typeof router.query.id === "string"
+      ? router.query.id
+      : router.query.id[0]
+  );
 
   const isGridVisible =
     viewport.zoom >= ZOOM_GRID_LEVEL &&
@@ -346,30 +345,6 @@ function Map(props: MapProps) {
       }
     };
   }, [data, newParcel.id, fetchMore]);
-
-  const flyToLocation = useCallback(
-    ({
-      longitude,
-      latitude,
-      duration,
-      zoom,
-      padding,
-    }: {
-      longitude: number;
-      latitude: number;
-      duration: number;
-      zoom: number;
-      padding: PaddingOptions;
-    }) => {
-      mapRef.current?.flyTo({
-        center: [longitude, latitude],
-        duration,
-        zoom,
-        padding: padding,
-      });
-    },
-    []
-  );
 
   function updateGrid(
     lat: number,
@@ -469,27 +444,20 @@ function Map(props: MapProps) {
 
     const { query } = router;
 
-    if (query.longitude && query.latitude && query.id) {
-      flyToLocation({
-        longitude: Number(query.longitude),
-        latitude: Number(query.latitude),
-        zoom: isMobile || isTablet ? ZOOM_GRID_LEVEL - 1 : ZOOM_GRID_LEVEL,
-        duration: 500,
-        padding: {
-          ...mapPadding,
-          left: !isMobile && !isTablet ? document.body.offsetWidth * 0.25 : 0,
-          bottom: isMobile || isTablet ? DRAWER_PREVIEW_HEIGHT_PARCEL : 0,
-        },
-      });
+    if (query.id) {
+      const coords = getParcelCoords();
 
-      setSelectedParcelId(
-        typeof query.id === "string" ? query.id : query.id[0]
-      );
-      setInteractionState(STATE.PARCEL_SELECTED);
-      setSelectedParcelCoords({
-        x: Number(query.longitude),
-        y: Number(query.latitude),
-      });
+      if (coords) {
+        flyToParcel({
+          center: coords,
+          duration: 500,
+        });
+
+        setSelectedParcelId(
+          typeof query.id === "string" ? query.id : query.id[0]
+        );
+        setInteractionState(STATE.PARCEL_SELECTED);
+      }
     }
   }
 
@@ -605,10 +573,6 @@ function Map(props: MapProps) {
     );
 
     function _checkParcelClick() {
-      setSelectedParcelCoords({
-        x: event.lngLat.lng,
-        y: event.lngLat.lat,
-      });
       if (parcelFeature) {
         setSelectedParcelId(parcelFeature.properties?.parcelId);
         setInteractionState(STATE.PARCEL_SELECTED);
@@ -758,16 +722,14 @@ function Map(props: MapProps) {
           setCellHoverCoord(null);
           setInteractionState(STATE.CLAIM_SELECTING);
         } else {
-          flyToLocation({
-            longitude: event.lngLat.lng,
-            latitude: event.lngLat.lat,
+          mapRef.current?.easeTo({
+            center: [event.lngLat.lng, event.lngLat.lat],
             zoom: ZOOM_GRID_LEVEL,
             duration: 500,
-            padding: mapPadding,
           });
         }
 
-        mapRef?.current?.moveLayer("claim-point-layer");
+        mapRef.current?.moveLayer("claim-point-layer");
         break;
       case STATE.CLAIM_SELECTED:
         setInteractionState(STATE.VIEWING);
@@ -1012,27 +974,6 @@ function Map(props: MapProps) {
   }, [data]);
 
   useEffect(() => {
-    if (parcelNavigationCenter) {
-      flyToLocation({
-        longitude: parcelNavigationCenter.coordinates[0],
-        latitude: parcelNavigationCenter.coordinates[1],
-        zoom: isMobile || isTablet ? ZOOM_GRID_LEVEL - 1 : ZOOM_GRID_LEVEL,
-        duration: 500,
-        padding: {
-          ...mapPadding,
-          left: !isMobile && !isTablet ? document.body.offsetWidth * 0.25 : 0,
-          bottom: isMobile || isTablet ? DRAWER_PREVIEW_HEIGHT_PARCEL : 0,
-        },
-      });
-
-      setSelectedParcelCoords({
-        x: parcelNavigationCenter.coordinates[0],
-        y: parcelNavigationCenter.coordinates[1],
-      });
-    }
-  }, [parcelNavigationCenter]);
-
-  useEffect(() => {
     if (!showSearchBar) {
       return;
     }
@@ -1105,7 +1046,6 @@ function Map(props: MapProps) {
           invalidLicenseId={invalidLicenseId}
           setInvalidLicenseId={setInvalidLicenseId}
           setNewParcel={setNewParcel}
-          selectedParcelCoords={selectedParcelCoords}
           isValidClaim={isValidClaim}
           delay={interactionState === STATE.CLAIM_SELECTING}
         ></OffCanvasPanel>
@@ -1230,12 +1170,10 @@ function Map(props: MapProps) {
               : "visible",
         }}
         onClick={() =>
-          flyToLocation({
-            longitude: viewport.longitude,
-            latitude: viewport.latitude,
+          mapRef.current?.easeTo({
+            center: [viewport.longitude, viewport.latitude],
             zoom: ZOOM_GRID_LEVEL,
             duration: 500,
-            padding: mapPadding,
           })
         }
       >

--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -422,7 +422,7 @@ function Map(props: MapProps) {
       return;
     }
 
-    if (process.env.NEXT_PUBLIC_APP_ENV === "testnet") {
+    if (process.env.NEXT_PUBLIC_APP_ENV === "testnet" && !router.query.id) {
       mapRef.current.easeTo({
         center: [viewport.longitude, viewport.latitude],
         zoom: 13,

--- a/components/OffCanvasPanel.tsx
+++ b/components/OffCanvasPanel.tsx
@@ -22,7 +22,6 @@ export type OffCanvasPanelProps = MapProps & {
   selectedParcelId: string;
   setSelectedParcelId: React.Dispatch<React.SetStateAction<string>>;
   setIsParcelAvailable: React.Dispatch<React.SetStateAction<boolean>>;
-  selectedParcelCoords: Coord | null;
   parcelClaimInfo: ParcelClaimInfo;
   invalidLicenseId: string;
   setInvalidLicenseId: React.Dispatch<React.SetStateAction<string>>;
@@ -47,7 +46,6 @@ function OffCanvasPanel(props: OffCanvasPanelProps) {
     setInteractionState,
     parcelClaimInfo,
     selectedParcelId,
-    selectedParcelCoords,
     isValidClaim,
     delay,
   } = props;
@@ -266,7 +264,6 @@ function OffCanvasPanel(props: OffCanvasPanelProps) {
           perSecondFeeNumerator={perSecondFeeNumerator}
           perSecondFeeDenominator={perSecondFeeDenominator}
           minForSalePrice={minForSalePrice}
-          selectedParcelCoords={selectedParcelCoords}
           parcelFieldsToUpdate={parcelFieldsToUpdate}
           setParcelFieldsToUpdate={setParcelFieldsToUpdate}
           licenseAddress={registryContract.address}

--- a/components/cards/ParcelInfo.tsx
+++ b/components/cards/ParcelInfo.tsx
@@ -36,6 +36,7 @@ import { GeoWebContent } from "@geo-web/content";
 import { PCOLicenseDiamondFactory } from "@geo-web/sdk/dist/contract/index";
 import type { IPCOLicenseDiamond } from "@geo-web/contracts/dist/typechain-types/IPCOLicenseDiamond";
 import { useMediaQuery } from "../../lib/mediaQuery";
+import { useParcelNavigation } from "../../lib/parcelNavigation";
 
 const ParcelChat = dynamic(() => import("../ParcelChat"), {
   ssr: false,
@@ -116,7 +117,6 @@ function ParcelInfo(props: ParcelInfoProps) {
     geoWebContent,
     invalidLicenseId,
     setInvalidLicenseId,
-    selectedParcelCoords,
     parcelFieldsToUpdate,
     setParcelFieldsToUpdate,
     sfFramework,
@@ -148,6 +148,7 @@ function ParcelInfo(props: ParcelInfoProps) {
       data?.geoWebParcel?.licenseOwner,
       selectedParcelId
     );
+  const { getParcelCoords } = useParcelNavigation(selectedParcelId);
 
   const spinner = (
     <Spinner as="span" size="sm" animation="border" role="status">
@@ -155,6 +156,7 @@ function ParcelInfo(props: ParcelInfoProps) {
     </Spinner>
   );
 
+  const selectedParcelCoords = getParcelCoords();
   const forSalePrice =
     data && data.geoWebParcel ? (
       <>
@@ -189,14 +191,8 @@ function ParcelInfo(props: ParcelInfoProps) {
   const licenseDiamondAddress = data?.geoWebParcel?.licenseDiamond;
 
   function copyParcelLink() {
-    if (!selectedParcelCoords) {
-      return;
-    }
-
     const parcelLink = new URL(window.location.origin);
 
-    parcelLink.searchParams.set("latitude", selectedParcelCoords.y.toString());
-    parcelLink.searchParams.set("longitude", selectedParcelCoords.x.toString());
     parcelLink.searchParams.set("id", selectedParcelId);
 
     navigator.clipboard.writeText(parcelLink.href);
@@ -392,7 +388,9 @@ function ParcelInfo(props: ParcelInfoProps) {
       </>
     );
   } else {
-    const spatialURL = `${SPATIAL_DOMAIN}?latitude=${selectedParcelCoords?.y}&longitude=${selectedParcelCoords?.x}`;
+    const spatialURL = selectedParcelCoords
+      ? `${SPATIAL_DOMAIN}?latitude=${selectedParcelCoords[1]}&longitude=${selectedParcelCoords[0]}`
+      : SPATIAL_DOMAIN;
     header =
       interactionState === STATE.PARCEL_SELECTED || (!isMobile && !isTablet) ? (
         <>
@@ -465,7 +463,7 @@ function ParcelInfo(props: ParcelInfoProps) {
                 </OverlayTrigger>
                 <CopyTooltip
                   contentClick="Link Copied"
-                  contentHover="Copy link to Parcel"
+                  contentHover="Copy Parcel Link"
                   target={
                     <Image
                       className="me-1"

--- a/components/cards/StreamingInfo.tsx
+++ b/components/cards/StreamingInfo.tsx
@@ -5,7 +5,6 @@ import Row from "react-bootstrap/Row";
 import Container from "react-bootstrap/Container";
 import Spinner from "react-bootstrap/Spinner";
 import { CeramicClient } from "@ceramicnetwork/http-client";
-import type { Point } from "@turf/turf";
 import type { IPFS } from "ipfs-core-types";
 import { Contracts } from "@geo-web/sdk/dist/contract/types";
 import { GeoWebContent } from "@geo-web/content";
@@ -30,7 +29,6 @@ type StreamingInfoProps = {
   setSelectedParcelId: React.Dispatch<React.SetStateAction<string>>;
   setInteractionState: React.Dispatch<React.SetStateAction<STATE>>;
   setPortfolioNeedActionCount: React.Dispatch<React.SetStateAction<number>>;
-  setParcelNavigationCenter: React.Dispatch<React.SetStateAction<Point | null>>;
   shouldRefetchParcelsData: boolean;
   setShouldRefetchParcelsData: React.Dispatch<React.SetStateAction<boolean>>;
 };

--- a/components/parcels/Foreclosure.tsx
+++ b/components/parcels/Foreclosure.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 import { BigNumber } from "ethers";
 import { gql, useQuery } from "@apollo/client";
 import { Framework } from "@superfluid-finance/sdk-core";
-import type { Point } from "@turf/turf";
 import * as turf from "@turf/turf";
 import { GeoWebContent } from "@geo-web/content";
 import { Contracts } from "@geo-web/sdk/dist/contract/types";
@@ -18,13 +17,12 @@ interface ForeclosureProps {
   registryContract: Contracts["registryDiamondContract"];
   setSelectedParcelId: React.Dispatch<React.SetStateAction<string>>;
   setInteractionState: React.Dispatch<React.SetStateAction<STATE>>;
-  handleCloseModal: () => void;
-  setParcelNavigationCenter: React.Dispatch<React.SetStateAction<Point | null>>;
   shouldRefetchParcelsData: boolean;
   setShouldRefetchParcelsData: React.Dispatch<React.SetStateAction<boolean>>;
   hasRefreshed: boolean;
   setHasRefreshed: React.Dispatch<React.SetStateAction<boolean>>;
   maxListSize: number;
+  handleAction: (parcel: Parcel) => void;
 }
 
 type Bid = Parcel & {
@@ -62,15 +60,12 @@ function Foreclosure(props: ForeclosureProps) {
     sfFramework,
     geoWebContent,
     registryContract,
-    setSelectedParcelId,
-    setInteractionState,
-    handleCloseModal,
-    setParcelNavigationCenter,
     shouldRefetchParcelsData,
     setShouldRefetchParcelsData,
     hasRefreshed,
     setHasRefreshed,
     maxListSize,
+    handleAction,
   } = props;
 
   const [parcels, setParcels] = useState<Bid[] | null>(null);
@@ -229,13 +224,6 @@ function Foreclosure(props: ForeclosureProps) {
     });
 
     return sorted;
-  };
-
-  const handleAction = (parcel: Parcel): void => {
-    handleCloseModal();
-    setInteractionState(STATE.PARCEL_SELECTED);
-    setSelectedParcelId(parcel.parcelId);
-    setParcelNavigationCenter(parcel.center);
   };
 
   return (

--- a/components/parcels/HighestValue.tsx
+++ b/components/parcels/HighestValue.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 import { BigNumber } from "ethers";
 import { gql, useQuery } from "@apollo/client";
 import { Framework } from "@superfluid-finance/sdk-core";
-import type { Point } from "@turf/turf";
 import * as turf from "@turf/turf";
 import { GeoWebContent } from "@geo-web/content";
 import { Contracts } from "@geo-web/sdk/dist/contract/types";
@@ -11,21 +10,17 @@ import { Parcel, ParcelsQuery } from "./ParcelList";
 import ParcelTable from "./ParcelTable";
 import { getParcelContent } from "../../lib/utils";
 import { SECONDS_IN_WEEK } from "../../lib/constants";
-import { STATE } from "../Map";
 
 interface HighestValueProps {
   sfFramework: Framework;
   geoWebContent: GeoWebContent;
   registryContract: Contracts["registryDiamondContract"];
-  setSelectedParcelId: React.Dispatch<React.SetStateAction<string>>;
-  setInteractionState: React.Dispatch<React.SetStateAction<STATE>>;
-  handleCloseModal: () => void;
-  setParcelNavigationCenter: React.Dispatch<React.SetStateAction<Point | null>>;
   shouldRefetchParcelsData: boolean;
   setShouldRefetchParcelsData: React.Dispatch<React.SetStateAction<boolean>>;
   hasRefreshed: boolean;
   setHasRefreshed: React.Dispatch<React.SetStateAction<boolean>>;
   maxListSize: number;
+  handleAction: (parcel: Parcel) => void;
 }
 
 const highestValueQuery = gql`
@@ -63,15 +58,12 @@ function HighestValue(props: HighestValueProps) {
     sfFramework,
     geoWebContent,
     registryContract,
-    setSelectedParcelId,
-    setInteractionState,
-    handleCloseModal,
-    setParcelNavigationCenter,
     shouldRefetchParcelsData,
     setShouldRefetchParcelsData,
     hasRefreshed,
     setHasRefreshed,
     maxListSize,
+    handleAction,
   } = props;
 
   const [parcels, setParcels] = useState<Parcel[] | null>(null);
@@ -245,13 +237,6 @@ function HighestValue(props: HighestValueProps) {
     });
 
     return sorted;
-  };
-
-  const handleAction = (parcel: Parcel): void => {
-    handleCloseModal();
-    setInteractionState(STATE.PARCEL_SELECTED);
-    setSelectedParcelId(parcel.parcelId);
-    setParcelNavigationCenter(parcel.center);
   };
 
   return (

--- a/components/parcels/NeedsTransfer.tsx
+++ b/components/parcels/NeedsTransfer.tsx
@@ -2,14 +2,12 @@ import { useState, useEffect } from "react";
 import { BigNumber } from "ethers";
 import { gql, useQuery } from "@apollo/client";
 import { Framework } from "@superfluid-finance/sdk-core";
-import type { Point } from "@turf/turf";
 import * as turf from "@turf/turf";
 import { GeoWebContent } from "@geo-web/content";
 import { Contracts } from "@geo-web/sdk/dist/contract/types";
 import { PCOLicenseDiamondFactory } from "@geo-web/sdk/dist/contract/index";
 import { Parcel, ParcelsQuery } from "./ParcelList";
 import ParcelTable from "./ParcelTable";
-import { STATE } from "../Map";
 import { getParcelContent } from "../../lib/utils";
 import { SECONDS_IN_WEEK } from "../../lib/constants";
 
@@ -17,15 +15,12 @@ interface NeedsTransferProps {
   sfFramework: Framework;
   geoWebContent: GeoWebContent;
   registryContract: Contracts["registryDiamondContract"];
-  setSelectedParcelId: React.Dispatch<React.SetStateAction<string>>;
-  setInteractionState: React.Dispatch<React.SetStateAction<STATE>>;
-  handleCloseModal: () => void;
-  setParcelNavigationCenter: React.Dispatch<React.SetStateAction<Point | null>>;
   shouldRefetchParcelsData: boolean;
   setShouldRefetchParcelsData: React.Dispatch<React.SetStateAction<boolean>>;
   hasRefreshed: boolean;
   setHasRefreshed: React.Dispatch<React.SetStateAction<boolean>>;
   maxListSize: number;
+  handleAction: (parcel: Parcel) => void;
 }
 
 type Bid = Parcel & {
@@ -64,15 +59,12 @@ function NeedsTransfer(props: NeedsTransferProps) {
     sfFramework,
     geoWebContent,
     registryContract,
-    setSelectedParcelId,
-    setInteractionState,
-    handleCloseModal,
-    setParcelNavigationCenter,
     shouldRefetchParcelsData,
     setShouldRefetchParcelsData,
     hasRefreshed,
     setHasRefreshed,
     maxListSize,
+    handleAction,
   } = props;
 
   const [parcels, setParcels] = useState<Bid[] | null>(null);
@@ -238,13 +230,6 @@ function NeedsTransfer(props: NeedsTransferProps) {
     });
 
     return sorted;
-  };
-
-  const handleAction = (parcel: Parcel): void => {
-    handleCloseModal();
-    setInteractionState(STATE.PARCEL_SELECTED);
-    setSelectedParcelId(parcel.parcelId);
-    setParcelNavigationCenter(parcel.center);
   };
 
   return (

--- a/components/parcels/OutstandingBid.tsx
+++ b/components/parcels/OutstandingBid.tsx
@@ -2,28 +2,23 @@ import { useState, useEffect } from "react";
 import { BigNumber } from "ethers";
 import { gql, useQuery } from "@apollo/client";
 import { Framework } from "@superfluid-finance/sdk-core";
-import type { Point } from "@turf/turf";
 import * as turf from "@turf/turf";
 import { GeoWebContent } from "@geo-web/content";
 import { Contracts } from "@geo-web/sdk/dist/contract/types";
 import { Parcel, ParcelsQuery } from "./ParcelList";
 import ParcelTable from "./ParcelTable";
 import { getParcelContent } from "../../lib/utils";
-import { STATE } from "../Map";
 
 interface OutstandingBidProps {
   sfFramework: Framework;
   geoWebContent: GeoWebContent;
   registryContract: Contracts["registryDiamondContract"];
-  setSelectedParcelId: React.Dispatch<React.SetStateAction<string>>;
-  setInteractionState: React.Dispatch<React.SetStateAction<STATE>>;
-  handleCloseModal: () => void;
-  setParcelNavigationCenter: React.Dispatch<React.SetStateAction<Point | null>>;
   shouldRefetchParcelsData: boolean;
   setShouldRefetchParcelsData: React.Dispatch<React.SetStateAction<boolean>>;
   hasRefreshed: boolean;
   setHasRefreshed: React.Dispatch<React.SetStateAction<boolean>>;
   maxListSize: number;
+  handleAction: (parcel: Parcel) => void;
 }
 
 type Bid = Parcel & {
@@ -60,15 +55,12 @@ function OutstandingBid(props: OutstandingBidProps) {
   const {
     geoWebContent,
     registryContract,
-    setSelectedParcelId,
-    setInteractionState,
-    handleCloseModal,
-    setParcelNavigationCenter,
     shouldRefetchParcelsData,
     setShouldRefetchParcelsData,
     hasRefreshed,
     setHasRefreshed,
     maxListSize,
+    handleAction,
   } = props;
 
   const [parcels, setParcels] = useState<Bid[] | null>(null);
@@ -214,13 +206,6 @@ function OutstandingBid(props: OutstandingBidProps) {
     });
 
     return sorted;
-  };
-
-  const handleAction = (parcel: Parcel): void => {
-    handleCloseModal();
-    setInteractionState(STATE.PARCEL_SELECTED);
-    setSelectedParcelId(parcel.parcelId);
-    setParcelNavigationCenter(parcel.center);
   };
 
   return (

--- a/components/parcels/ParcelList.tsx
+++ b/components/parcels/ParcelList.tsx
@@ -13,6 +13,7 @@ import OutstandingBid from "./OutstandingBid";
 import { STATE } from "../Map";
 import type { Point } from "@turf/turf";
 import { useMediaQuery } from "../../lib/mediaQuery";
+import { useParcelNavigation } from "../../lib/parcelNavigation";
 
 interface ParcelListProps {
   sfFramework: Framework;
@@ -21,7 +22,6 @@ interface ParcelListProps {
   setSelectedParcelId: React.Dispatch<React.SetStateAction<string>>;
   setInteractionState: React.Dispatch<React.SetStateAction<STATE>>;
   showParcelList: boolean;
-  setParcelNavigationCenter: React.Dispatch<React.SetStateAction<Point | null>>;
   shouldRefetchParcelsData: boolean;
   setShouldRefetchParcelsData: React.Dispatch<React.SetStateAction<boolean>>;
   handleCloseModal: () => void;
@@ -69,13 +69,19 @@ export enum QuerySelection {
 }
 
 function ParcelList(props: ParcelListProps) {
-  const { showParcelList, handleCloseModal } = props;
-  const { isMobile } = useMediaQuery();
-
+  const {
+    showParcelList,
+    handleCloseModal,
+    setSelectedParcelId,
+    setInteractionState,
+  } = props;
   const [querySelected, setQuerySelected] = useState<QuerySelection>(
     QuerySelection.HIGHEST_VALUE
   );
   const [hasRefreshed, setHasRefreshed] = useState<boolean>(false);
+
+  const { isMobile } = useMediaQuery();
+  const { flyToParcel } = useParcelNavigation();
 
   const maxListSize = isMobile ? 10 : 25;
 
@@ -86,6 +92,18 @@ function ParcelList(props: ParcelListProps) {
     }
 
     setQuerySelected(selection);
+  };
+
+  const handleAction = (parcel: Parcel): void => {
+    const [lng, lat] = parcel.center.coordinates;
+
+    handleCloseModal();
+    setInteractionState(STATE.PARCEL_SELECTED);
+    setSelectedParcelId(parcel.parcelId);
+    flyToParcel({
+      center: [lng, lat],
+      duration: 500,
+    });
   };
 
   return (
@@ -149,6 +167,7 @@ function ParcelList(props: ParcelListProps) {
             hasRefreshed={hasRefreshed}
             setHasRefreshed={setHasRefreshed}
             maxListSize={maxListSize}
+            handleAction={handleAction}
             {...props}
           />
         ) : querySelected === QuerySelection.RECENT ? (
@@ -156,6 +175,7 @@ function ParcelList(props: ParcelListProps) {
             hasRefreshed={hasRefreshed}
             setHasRefreshed={setHasRefreshed}
             maxListSize={maxListSize}
+            handleAction={handleAction}
             {...props}
           />
         ) : querySelected === QuerySelection.RANDOM ? (
@@ -163,6 +183,7 @@ function ParcelList(props: ParcelListProps) {
             hasRefreshed={hasRefreshed}
             setHasRefreshed={setHasRefreshed}
             maxListSize={maxListSize}
+            handleAction={handleAction}
             {...props}
           />
         ) : querySelected === QuerySelection.NEEDS_TRASFER ? (
@@ -170,6 +191,7 @@ function ParcelList(props: ParcelListProps) {
             hasRefreshed={hasRefreshed}
             setHasRefreshed={setHasRefreshed}
             maxListSize={maxListSize}
+            handleAction={handleAction}
             {...props}
           />
         ) : querySelected === QuerySelection.FORECLOSURE ? (
@@ -177,6 +199,7 @@ function ParcelList(props: ParcelListProps) {
             hasRefreshed={hasRefreshed}
             setHasRefreshed={setHasRefreshed}
             maxListSize={maxListSize}
+            handleAction={handleAction}
             {...props}
           />
         ) : querySelected === QuerySelection.OUTSTANDING_BID ? (
@@ -184,6 +207,7 @@ function ParcelList(props: ParcelListProps) {
             hasRefreshed={hasRefreshed}
             setHasRefreshed={setHasRefreshed}
             maxListSize={maxListSize}
+            handleAction={handleAction}
             {...props}
           />
         ) : null}

--- a/components/parcels/Recent.tsx
+++ b/components/parcels/Recent.tsx
@@ -2,14 +2,12 @@ import { useState, useEffect } from "react";
 import { BigNumber } from "ethers";
 import { gql, useQuery } from "@apollo/client";
 import { Framework } from "@superfluid-finance/sdk-core";
-import type { Point } from "@turf/turf";
 import * as turf from "@turf/turf";
 import { GeoWebContent } from "@geo-web/content";
 import { Contracts } from "@geo-web/sdk/dist/contract/types";
 import { PCOLicenseDiamondFactory } from "@geo-web/sdk/dist/contract/index";
 import { Parcel, ParcelsQuery } from "./ParcelList";
 import ParcelTable from "./ParcelTable";
-import { STATE } from "../Map";
 import { getParcelContent } from "../../lib/utils";
 import { SECONDS_IN_WEEK } from "../../lib/constants";
 
@@ -17,15 +15,12 @@ interface RecentProps {
   sfFramework: Framework;
   geoWebContent: GeoWebContent;
   registryContract: Contracts["registryDiamondContract"];
-  setSelectedParcelId: React.Dispatch<React.SetStateAction<string>>;
-  setInteractionState: React.Dispatch<React.SetStateAction<STATE>>;
-  handleCloseModal: () => void;
-  setParcelNavigationCenter: React.Dispatch<React.SetStateAction<Point | null>>;
   shouldRefetchParcelsData: boolean;
   setShouldRefetchParcelsData: React.Dispatch<React.SetStateAction<boolean>>;
   hasRefreshed: boolean;
   setHasRefreshed: React.Dispatch<React.SetStateAction<boolean>>;
   maxListSize: number;
+  handleAction: (parcel: Parcel) => void;
 }
 
 const recentQuery = gql`
@@ -63,15 +58,12 @@ function Recent(props: RecentProps) {
     sfFramework,
     geoWebContent,
     registryContract,
-    setSelectedParcelId,
-    setInteractionState,
-    handleCloseModal,
-    setParcelNavigationCenter,
     shouldRefetchParcelsData,
     setShouldRefetchParcelsData,
     hasRefreshed,
     setHasRefreshed,
     maxListSize,
+    handleAction,
   } = props;
 
   const [parcels, setParcels] = useState<Parcel[] | null>(null);
@@ -242,13 +234,6 @@ function Recent(props: RecentProps) {
     });
 
     return sorted;
-  };
-
-  const handleAction = (parcel: Parcel): void => {
-    handleCloseModal();
-    setInteractionState(STATE.PARCEL_SELECTED);
-    setSelectedParcelId(parcel.parcelId);
-    setParcelNavigationCenter(parcel.center);
   };
 
   return (

--- a/components/profile/Profile.tsx
+++ b/components/profile/Profile.tsx
@@ -6,7 +6,6 @@ import { CeramicClient } from "@ceramicnetwork/http-client";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import type { InvocationConfig } from "@web3-storage/upload-client";
-import type { Point } from "@turf/turf";
 import ProfileModal from "./ProfileModal";
 import { sfSubgraph } from "../../redux/store";
 import { NETWORK_ID } from "../../lib/constants";
@@ -40,7 +39,6 @@ type ProfileProps = {
   paymentToken: NativeAssetSuperToken;
   portfolioNeedActionCount: number;
   setPortfolioNeedActionCount: React.Dispatch<React.SetStateAction<number>>;
-  setParcelNavigationCenter: React.Dispatch<React.SetStateAction<Point | null>>;
   shouldRefetchParcelsData: boolean;
   setShouldRefetchParcelsData: React.Dispatch<React.SetStateAction<boolean>>;
 };

--- a/components/profile/ProfileModal.tsx
+++ b/components/profile/ProfileModal.tsx
@@ -48,6 +48,7 @@ import {
 } from "../../lib/utils";
 import { STATE } from "../Map";
 import { useMediaQuery } from "../../lib/mediaQuery";
+import { useParcelNavigation } from "../../lib/parcelNavigation";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -67,7 +68,6 @@ interface ProfileModalProps {
   paymentToken: NativeAssetSuperToken;
   showProfile: boolean;
   handleCloseProfile: () => void;
-  setParcelNavigationCenter: React.Dispatch<React.SetStateAction<Point | null>>;
   shouldRefetchParcelsData: boolean;
   setPortfolioNeedActionCount: React.Dispatch<React.SetStateAction<number>>;
   setShouldRefetchParcelsData: React.Dispatch<React.SetStateAction<boolean>>;
@@ -187,7 +187,6 @@ function ProfileModal(props: ProfileModalProps) {
     showProfile,
     handleCloseProfile,
     setPortfolioNeedActionCount,
-    setParcelNavigationCenter,
     shouldRefetchParcelsData,
     setShouldRefetchParcelsData,
   } = props;
@@ -211,12 +210,12 @@ function ProfileModal(props: ProfileModalProps) {
       id: account,
     },
   });
-
   const { superTokenBalance } = useSuperTokenBalance(
     account,
     paymentToken.address
   );
   const { isMobile, isTablet } = useMediaQuery();
+  const { flyToParcel } = useParcelNavigation();
 
   const paymentTokenBalance = ethers.utils.formatEther(superTokenBalance);
   const isOutOfBalanceWrap =
@@ -651,6 +650,8 @@ function ProfileModal(props: ProfileModalProps) {
   };
 
   const handlePortfolioAction = (parcel: PortfolioParcel): void => {
+    const [lng, lat] = parcel.center.coordinates;
+
     switch (parcel.action) {
       case PortfolioAction.VIEW:
       case PortfolioAction.RESPOND:
@@ -668,7 +669,10 @@ function ProfileModal(props: ProfileModalProps) {
 
     handleCloseProfile();
     setSelectedParcelId(parcel.parcelId);
-    setParcelNavigationCenter(parcel.center);
+    flyToParcel({
+      center: [lng, lat],
+      duration: 500,
+    });
   };
 
   return (

--- a/lib/parcelNavigation.ts
+++ b/lib/parcelNavigation.ts
@@ -1,0 +1,99 @@
+import { gql, useQuery } from "@apollo/client";
+import { LngLatLike } from "mapbox-gl";
+import { useMap } from "react-map-gl";
+import { ZOOM_GRID_LEVEL } from "../components/Map";
+import { DRAWER_PREVIEW_HEIGHT_PARCEL } from "./constants";
+import { useMediaQuery } from "./mediaQuery";
+
+export interface GeoWebParcel {
+  id: string;
+  bboxE: string;
+  bboxN: string;
+  bboxS: string;
+  bboxW: string;
+}
+
+export interface ParcelQuery {
+  geoWebParcel?: GeoWebParcel;
+}
+
+const parcelQuery = gql`
+  query GeoWebParcel($id: String) {
+    geoWebParcel(id: $id) {
+      id
+      bboxE
+      bboxN
+      bboxS
+      bboxW
+    }
+  }
+`;
+
+function useParcelNavigation(parcelId?: string) {
+  const { data, refetch } = useQuery<ParcelQuery>(parcelQuery, {
+    variables: {
+      id: parcelId,
+    },
+    skip: !parcelId,
+  });
+  const { isMobile, isTablet } = useMediaQuery();
+  const { default: map } = useMap();
+
+  const getParcelCenter = (geoWebParcel: GeoWebParcel): [number, number] => {
+    const { bboxE, bboxN, bboxS, bboxW } = geoWebParcel;
+
+    return [
+      (Number(bboxE) + Number(bboxW)) / 2,
+      (Number(bboxN) + Number(bboxS)) / 2,
+    ];
+  };
+
+  const getParcelCoords = (): [number, number] | null => {
+    if (!data?.geoWebParcel) {
+      return null;
+    }
+
+    return getParcelCenter(data.geoWebParcel);
+  };
+
+  const parcelIdToCoords = async (
+    parcelId: string
+  ): Promise<[number, number] | null> => {
+    const res = await refetch({ id: parcelId });
+
+    if (!res.data?.geoWebParcel) {
+      return null;
+    }
+
+    return getParcelCenter(res.data.geoWebParcel);
+  };
+
+  const flyToParcel = ({
+    center,
+    duration,
+  }: {
+    center: LngLatLike;
+    duration: number;
+  }): void => {
+    if (!map) {
+      throw new Error("Map was not found");
+    }
+
+    const mapPadding = map.getPadding();
+
+    map.flyTo({
+      center,
+      duration,
+      zoom: isMobile || isTablet ? ZOOM_GRID_LEVEL - 1 : ZOOM_GRID_LEVEL,
+      padding: {
+        ...mapPadding,
+        left: !isMobile && !isTablet ? document.body.offsetWidth * 0.25 : 0,
+        bottom: isMobile || isTablet ? DRAWER_PREVIEW_HEIGHT_PARCEL : 0,
+      },
+    });
+  };
+
+  return { getParcelCoords, parcelIdToCoords, flyToParcel };
+}
+
+export { useParcelNavigation };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -41,6 +41,8 @@ import { randomBytes, randomString } from "@stablelib/random";
 import { Cacao, SiweMessage as CacaoSiweMessage } from "@didtools/cacao";
 import { getEIP191Verifier } from "@didtools/pkh-ethereum";
 
+import { MapProvider } from "react-map-gl";
+
 const networkIdToChain: Record<number, Chain> = {
   5: goerli,
   10: optimism,
@@ -217,11 +219,13 @@ export function App({ Component, pageProps }: AppProps) {
           })}
         >
           <ApolloProvider client={client}>
-            <Component
-              {...pageProps}
-              authStatus={authStatus}
-              setAuthStatus={setAuthStatus}
-            />
+            <MapProvider>
+              <Component
+                {...pageProps}
+                authStatus={authStatus}
+                setAuthStatus={setAuthStatus}
+              />
+            </MapProvider>
           </ApolloProvider>
         </RainbowKitProvider>
       </RainbowKitAuthenticationProvider>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,4 @@
 import { wrapper } from "../redux/store";
-
 import React from "react";
 import {
   ApolloClient,
@@ -10,7 +9,7 @@ import {
 import { SUBGRAPH_URL, NETWORK_ID, RPC_URLS } from "../lib/constants";
 import "../styles.scss";
 import { AppProps } from "next/app";
-
+import { MapProvider } from "react-map-gl";
 import { configureChains, createClient, WagmiConfig } from "wagmi";
 import { goerli, optimism, optimismGoerli } from "wagmi/chains";
 import type { Chain } from "wagmi";
@@ -40,8 +39,6 @@ import { DID } from "dids";
 import { randomBytes, randomString } from "@stablelib/random";
 import { Cacao, SiweMessage as CacaoSiweMessage } from "@didtools/cacao";
 import { getEIP191Verifier } from "@didtools/pkh-ethereum";
-
-import { MapProvider } from "react-map-gl";
 
 const networkIdToChain: Record<number, Chain> = {
   5: goerli,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,7 +31,6 @@ import { Contracts } from "@geo-web/sdk/dist/contract/types";
 import { getIpfs, providers } from "ipfs-provider";
 import type { IPFS } from "ipfs-core-types";
 import * as IPFSCore from "ipfs-core";
-import type { Point } from "@turf/turf";
 import * as IPFSHttpClient from "ipfs-http-client";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -107,8 +106,6 @@ function IndexPage({
   const [interactionState, setInteractionState] = React.useState<STATE>(
     STATE.VIEWING
   );
-  const [parcelNavigationCenter, setParcelNavigationCenter] =
-    React.useState<Point | null>(null);
   const [shouldRefetchParcelsData, setShouldRefetchParcelsData] =
     React.useState(false);
   const [beneficiaryAddress, setBeneficiaryAddress] = React.useState("");
@@ -421,7 +418,6 @@ function IndexPage({
                 setSelectedParcelId={setSelectedParcelId}
                 interactionState={interactionState}
                 setInteractionState={setInteractionState}
-                setParcelNavigationCenter={setParcelNavigationCenter}
                 shouldRefetchParcelsData={shouldRefetchParcelsData}
                 setShouldRefetchParcelsData={setShouldRefetchParcelsData}
               />
@@ -475,9 +471,7 @@ function IndexPage({
               setSelectedParcelId={setSelectedParcelId}
               interactionState={interactionState}
               setInteractionState={setInteractionState}
-              parcelNavigationCenter={parcelNavigationCenter}
               shouldRefetchParcelsData={shouldRefetchParcelsData}
-              setParcelNavigationCenter={setParcelNavigationCenter}
               setShouldRefetchParcelsData={setShouldRefetchParcelsData}
               auctionStart={auctionStart}
               auctionEnd={auctionEnd}


### PR DESCRIPTION
# Description

Navigate to a parcel from an URL using only the parcel ID without the coordinates.

# Issue

fixes #408 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Additional comments

The `useParcelNavigation` custom hook takes an optional `parcelId` argument and returns some functions used to resolve the ID to GPS coordinates and to navigate to the parcel.
This replaces the current way to do parcel navigation from the modals allowing us to imperatively call Mapbox's `flyTo` from the event handler and avoid some rerender caused by `setState` and `useEffect`.

# Alert Reviewers

@codynhat @gravenp
