### PR TITLE
fix: use text input type and numeric inputmode

### DIFF
--- a/components/cards/ActionForm.tsx
+++ b/components/cards/ActionForm.tsx
@@ -285,7 +285,9 @@ export function ActionForm(props: ActionFormProps) {
     setInteractionState(STATE.PARCEL_SELECTED);
     setShouldRefetchParcelsData(true);
     setParcelFieldsToUpdate({
-      forSalePrice: !displayNewForSalePrice || displayNewForSalePrice !== displayCurrentForSalePrice,
+      forSalePrice:
+        !displayNewForSalePrice ||
+        displayNewForSalePrice !== displayCurrentForSalePrice,
       licenseOwner: !licenseOwner || licenseOwner !== account,
     });
   }
@@ -418,7 +420,8 @@ export function ActionForm(props: ActionFormProps) {
                     ? "bg-dark text-info mt-1"
                     : "bg-dark text-light mt-1"
                 }
-                type="number"
+                type="text"
+                inputMode="numeric"
                 placeholder={`New For Sale Price (${PAYMENT_TOKEN})`}
                 aria-label="For Sale Price"
                 aria-describedby="for-sale-price"

--- a/components/cards/PlaceBidAction.tsx
+++ b/components/cards/PlaceBidAction.tsx
@@ -255,7 +255,8 @@ function PlaceBidAction(props: PlaceBidActionProps) {
                 required
                 isInvalid={isForSalePriceInvalid}
                 className="bg-dark text-light mt-1"
-                type="number"
+                type="text"
+                inputMode="numeric"
                 placeholder={`New For Sale Price (${PAYMENT_TOKEN})`}
                 aria-label="For Sale Price"
                 aria-describedby="for-sale-price"

--- a/components/cards/RejectBidAction.tsx
+++ b/components/cards/RejectBidAction.tsx
@@ -356,7 +356,8 @@ function RejectBidAction(props: RejectBidActionProps) {
                 required
                 isInvalid={isForSalePriceInvalid}
                 className="bg-dark text-light mt-1"
-                type="number"
+                type="text"
+                inputMode="numeric"
                 placeholder={`New For Sale Price (${PAYMENT_TOKEN})`}
                 defaultValue={bidForSalePriceDisplay}
                 aria-label="For Sale Price"

--- a/styles.scss
+++ b/styles.scss
@@ -44,16 +44,6 @@ body {
   overscroll-behavior: none;
 }
 
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-input[type="number"] {
-  -moz-appearance: textfield;
-}
-
 .dropdown-menu {
   top: 68px !important;
 }


### PR DESCRIPTION
# Description

Use `type="text"` for the *For Sale Price* input field so that it doesn't have the incremental behaviour from wheel and arrow up/down, and `inputmode="numeric"` so that a numeric virtual keyboard is showed when the field is in focus.

# Issue

fixes #424 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
