### PR TITLE
feat: add tooltips to parcel name and content link input labels

### DIFF
--- a/components/InfoTooltip.tsx
+++ b/components/InfoTooltip.tsx
@@ -14,7 +14,12 @@ function InfoTooltip(props: InfoTooltipProps) {
 
   const handleMouseEnter = () => setShowTooltip(true);
   const handleMouseLeave = () => setShowTooltip(false);
-  const handleTouchEnd = () => setShowTooltip(!showTooltip);
+  const handleTouchEnd = () => {
+    setShowTooltip(true);
+    document.addEventListener("touchstart", () => setShowTooltip(false), {
+      once: true,
+    });
+  };
 
   return (
     <OverlayTrigger

--- a/components/cards/ActionForm.tsx
+++ b/components/cards/ActionForm.tsx
@@ -335,6 +335,23 @@ export function ActionForm(props: ActionFormProps) {
                   <Form.Text className="text-primary mb-1">
                     Parcel Name
                   </Form.Text>
+                  <InfoTooltip
+                    content={
+                      <div style={{ textAlign: "left" }}>
+                        Optional - Add a name to your parcel for all visitors to
+                        see.
+                      </div>
+                    }
+                    target={
+                      <Image
+                        style={{
+                          width: "1.1rem",
+                          marginLeft: "4px",
+                        }}
+                        src="info.svg"
+                      />
+                    }
+                  />
                   <Form.Control
                     isInvalid={isParcelNameInvalid}
                     className="bg-dark text-light mt-1"
@@ -355,8 +372,33 @@ export function ActionForm(props: ActionFormProps) {
                   ) : null}
                   <br />
                   <Form.Text className="text-primary mb-1">
-                    Content Link (http://, https://, ipfs://, ipns://)
+                    Content Link
                   </Form.Text>
+                  <InfoTooltip
+                    content={
+                      <div style={{ textAlign: "left" }}>
+                        Optional - Link content to your parcel via URI. This is
+                        displayed in an iframe on the{" "}
+                        <a
+                          href="https://geoweb.app/"
+                          target="_blank"
+                          rel="noopener"
+                        >
+                          Geo Web spatial browser
+                        </a>
+                        .
+                      </div>
+                    }
+                    target={
+                      <Image
+                        style={{
+                          width: "1.1rem",
+                          marginLeft: "4px",
+                        }}
+                        src="info.svg"
+                      />
+                    }
+                  />
                   <Form.Control
                     isInvalid={isURIInvalid}
                     className="bg-dark text-light mt-1"

--- a/components/cards/ClaimAction.tsx
+++ b/components/cards/ClaimAction.tsx
@@ -157,6 +157,7 @@ function ClaimAction(props: ClaimActionProps) {
 
           const referrals = JSON.parse(
             localStorage.getItem("referrals") ?? "[]"
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
           ) as any[];
           referrals.push(JSON.stringify(jwt));
           localStorage.setItem("referrals", JSON.stringify(referrals));


### PR DESCRIPTION
# Description

Add tooltips to *Parcel Name* and *Content Link* input labels.

# Issue

fixes #409 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x ] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
