### PR TITLE
fix: do not validate balance and claim size during transaction processing

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -322,6 +322,8 @@ function Map(props: MapProps) {
       if (lastParcel?.id === newParcel.id) {
         clearInterval(newParcel.timerId ?? undefined);
         setNewParcel({ id: "", timerId: null });
+        setClaimBase1Coord(null);
+        setClaimBase2Coord(null);
         return;
       }
 

--- a/components/cards/ActionForm.tsx
+++ b/components/cards/ActionForm.tsx
@@ -570,7 +570,7 @@ export function ActionForm(props: ActionFormProps) {
           </Form>
 
           <br />
-          {isBalanceInsufficient && displayNewForSalePrice ? (
+          {isBalanceInsufficient && displayNewForSalePrice && !isActing ? (
             <Alert key="warning" variant="warning">
               <Alert.Heading>Insufficient ETHx</Alert.Heading>
               Please wrap enough ETH to ETHx to complete this transaction with

--- a/components/cards/PlaceBidAction.tsx
+++ b/components/cards/PlaceBidAction.tsx
@@ -356,7 +356,7 @@ function PlaceBidAction(props: PlaceBidActionProps) {
           </Form>
 
           <br />
-          {isBalanceInsufficient && displayNewForSalePrice ? (
+          {isBalanceInsufficient && displayNewForSalePrice && !isActing ? (
             <Alert key="warning" variant="warning">
               <Alert.Heading>Insufficient ETHx</Alert.Heading>
               Please wrap enough ETH to ETHx to complete this transaction with

--- a/components/cards/RejectBidAction.tsx
+++ b/components/cards/RejectBidAction.tsx
@@ -460,7 +460,7 @@ function RejectBidAction(props: RejectBidActionProps) {
           </Form>
 
           <br />
-          {isBalanceInsufficient && displayNewForSalePrice ? (
+          {isBalanceInsufficient && displayNewForSalePrice && !isActing ? (
             <Alert key="warning" variant="warning">
               <Alert.Heading>Insufficient ETHx</Alert.Heading>
               Please wrap enough ETH to ETHx to complete this transaction with


### PR DESCRIPTION
# Description

Prevent balance and claim size/position validation after the claim is already made and before switching to the new parcel view.

# Issue

fixes #430 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
