### PR TITLE
fix: memoize graphQL client

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -162,6 +162,30 @@ export function App({ Component, pageProps }: AppProps) {
     [setAuthStatus]
   );
 
+  const client = React.useMemo(
+    () =>
+      new ApolloClient({
+        link: new HttpLink({
+          uri: SUBGRAPH_URL,
+        }),
+        cache: new InMemoryCache({
+          typePolicies: {
+            Query: {
+              fields: {
+                geoWebParcels: {
+                  keyArgs: ["skip", "orderBy"],
+                  merge(existing = [], incoming) {
+                    return [...existing, ...incoming];
+                  },
+                },
+              },
+            },
+          },
+        }),
+      }),
+    []
+  );
+
   React.useEffect(() => {
     (async () => {
       const sessionStr = localStorage.getItem("didsession");
@@ -178,26 +202,6 @@ export function App({ Component, pageProps }: AppProps) {
       }
     })();
   }, []);
-
-  const client = new ApolloClient({
-    link: new HttpLink({
-      uri: SUBGRAPH_URL,
-    }),
-    cache: new InMemoryCache({
-      typePolicies: {
-        Query: {
-          fields: {
-            geoWebParcels: {
-              keyArgs: ["skip", "orderBy"],
-              merge(existing = [], incoming) {
-                return [...existing, ...incoming];
-              },
-            },
-          },
-        },
-      },
-    }),
-  });
 
   return (
     <WagmiConfig client={wagmiClient}>


### PR DESCRIPTION
# Description

Memoize the `ApolloClient` instance so that when `/pages/_app.tsx` re-render after `setAuthStatus` we continue using the first client instead of assign a new one and lose the cached data.

# Issue

fixes #434 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
