### PR TITLE
fix: reduce icons size in parcel info view

### DIFF
--- a/components/NotificationModal.tsx
+++ b/components/NotificationModal.tsx
@@ -10,12 +10,11 @@ import { truncateStr } from "../lib/truncate";
 
 type NotificationModalProps = {
   isMobile: boolean;
-  isTablet: boolean;
   licenseDiamondAddress: string;
 };
 
 function NotificationModal(props: NotificationModalProps) {
-  const { isMobile, isTablet, licenseDiamondAddress } = props;
+  const { isMobile, licenseDiamondAddress } = props;
 
   const [show, setShow] = useState<boolean>(false);
 
@@ -37,7 +36,7 @@ function NotificationModal(props: NotificationModalProps) {
           <Image
             src="notification-add.svg"
             alt="add notification"
-            width={isMobile || isTablet ? 26 : 32}
+            width={26}
           ></Image>
         </Button>
       </OverlayTrigger>

--- a/components/cards/ParcelInfo.tsx
+++ b/components/cards/ParcelInfo.tsx
@@ -416,10 +416,9 @@ function ParcelInfo(props: ParcelInfoProps) {
                   className="d-block text-light fw-bold text-truncate"
                 >{`${hrefWebContent}`}</a>
               ) : null}
-              <div className="d-flex justify-content-end gap-1 gap-sm-2 text-end pt-2 mb-1 mb-sm-0  mx-sm-2">
+              <div className="d-flex justify-content-end gap-1 text-end pt-2 mb-1 mb-sm-0  mx-sm-2">
                 <NotificationModal
                   isMobile={isMobile}
-                  isTablet={isTablet}
                   licenseDiamondAddress={licenseDiamondAddress ?? ""}
                 />
                 <OverlayTrigger
@@ -435,7 +434,7 @@ function ParcelInfo(props: ParcelInfoProps) {
                     className="p-0 mt-1 shadow-none"
                     onClick={() => setShowParcelChat(true)}
                   >
-                    <Image width={isMobile ? 24 : 32} src="chat.svg" />
+                    <Image width={24} src="chat.svg" />
                   </Button>
                 </OverlayTrigger>
                 <OverlayTrigger
@@ -455,7 +454,7 @@ function ParcelInfo(props: ParcelInfoProps) {
                     target="_blank"
                   >
                     <Image
-                      width={isMobile ? 24 : 32}
+                      width={24}
                       src="open-in-browser.svg"
                     />
                   </Button>
@@ -466,7 +465,7 @@ function ParcelInfo(props: ParcelInfoProps) {
                   target={
                     <Image
                       className="me-1"
-                      width={isMobile ? 30 : 36}
+                      width={30}
                       src="link.svg"
                     />
                   }


### PR DESCRIPTION
# Description

Reduce the size of the icons in the parcel info view.

# Issue

fixes #439 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
