### PR TITLE
feat: add bedrock upgrade downtime alert

### DIFF
--- a/components/BedrockDowntimeAlert.tsx
+++ b/components/BedrockDowntimeAlert.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import Image from "react-bootstrap/Image";
+import { useMediaQuery } from "../lib/mediaQuery";
+
+function BedrockDowntimeAlert() {
+  const [show, setShow] = useState<boolean>(true);
+
+  const { isMobile, isTablet } = useMediaQuery();
+
+  return (
+    <Alert
+      show={show}
+      className="d-flex align-items-center gap-3 bg-dark border-0 text-light px-2 px-sm-3"
+      style={{
+        position: "absolute",
+        top: "105px",
+        left: "50%",
+        zIndex: 10,
+        transform: "translateX(-50%)",
+        width: isMobile ? "355px" : isTablet ? "420px" : "450px",
+      }}
+    >
+      <Button
+        variant="link"
+        size="sm"
+        className="position-absolute top-0 end-0 p-1 px-sm-1 py-sm-1"
+        onClick={() => setShow(false)}
+      >
+        <Image width={isMobile ? 26 : 28} src="close.svg" />
+      </Button>
+      <Image src="op.png" alt="op" width={52} height={52} />
+      <div
+        className="px-1"
+        style={{ fontSize: isMobile ? "0.9rem" : "1.0rem" }}
+      >
+        Notice: The Optimism network will undergo its{" "}
+        <a
+          href="https://oplabs.notion.site/Bedrock-Mission-Control-EXTERNAL-fca344b1f799447cb1bcf3aae62157c5"
+          target="_blank"
+          rel="noreferrer"
+          className="text-light text-decoration-underline"
+        >
+          Bedrock upgrade
+        </a>{" "}
+        and 2-4 hours of downtime starting at 16:00 UTC on June 6th. <br />
+        You will not be able to transact on the Geo Web during this upgrade.
+        <br />
+        <a
+          href="https://twitter.com/thegeoweb"
+          target="_blank"
+          rel="noreferrer"
+          className="text-light text-decoration-underline"
+        >
+          Follow us on Twitter
+        </a>{" "}
+        for updates.
+      </div>
+    </Alert>
+  );
+}
+
+export default BedrockDowntimeAlert;

--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -24,7 +24,7 @@ import {
   DRAWER_CLAIM_HEIGHT,
 } from "../lib/constants";
 import ParcelSource, { parcelsToMultiPoly } from "./sources/ParcelSource";
-import OpRewardAlert from "./OpRewardAlert";
+import BedrockDowntimeAlert from "./BedrockDowntimeAlert";
 
 import { Contracts } from "@geo-web/sdk/dist/contract/types";
 import { GeoWebContent } from "@geo-web/content";
@@ -1007,7 +1007,7 @@ function Map(props: MapProps) {
 
   return (
     <>
-      <OpRewardAlert />
+      <BedrockDowntimeAlert />
       {interactionState === STATE.CLAIM_SELECTING &&
         viewport.zoom < ZOOM_GRID_LEVEL && (
           <Alert


### PR DESCRIPTION
# Description

Replace the OP reward program pop-up with a warning for the downtime expected when the OP network will upgrade to the Bedrock architecture.

# Issue

fixes #444 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
