### PR TITLE
feat: start showing grid more zoomed out on mobile

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -54,9 +54,6 @@ import ParcelList from "./parcels/ParcelList";
 import { useMediaQuery } from "../lib/mediaQuery";
 import { useParcelNavigation } from "../lib/parcelNavigation";
 
-export const ZOOM_GRID_LEVEL = 17;
-const GRID_DIM_LAT = 140;
-const GRID_DIM_LON = 80;
 export const GW_CELL_SIZE_LAT = 23;
 export const GW_CELL_SIZE_LON = 24;
 export const GW_MAX_LAT = (1 << (GW_CELL_SIZE_LAT - 1)) - 1;
@@ -314,8 +311,9 @@ function Map(props: MapProps) {
   const router = useRouter();
   const { parcelIdToCoords, flyToParcel } = useParcelNavigation();
 
+  const gridZoomLevel = isMobile ? 16 : 17;
   const isGridVisible =
-    viewport.zoom >= ZOOM_GRID_LEVEL &&
+    viewport.zoom >= gridZoomLevel &&
     (interactionState === STATE.VIEWING ||
       interactionState === STATE.CLAIM_SELECTING);
 
@@ -358,18 +356,20 @@ function Map(props: MapProps) {
     const gwCoord = geoWebCoordinate.from_gps(lon, lat, GW_MAX_LAT);
     const x = geoWebCoordinate.get_x(gwCoord);
     const y = geoWebCoordinate.get_y(gwCoord);
+    const gridDimLat = isMobile ? 100 : 140;
+    const gridDimLon = isMobile ? 120 : 80;
 
     if (
       oldGrid != null &&
-      Math.abs(oldGrid.center.x - x) < GRID_DIM_LAT / 4 &&
-      Math.abs(oldGrid.center.y - y) < GRID_DIM_LON / 4
+      Math.abs(oldGrid.center.x - x) < gridDimLat / 4 &&
+      Math.abs(oldGrid.center.y - y) < gridDimLon / 4
     ) {
       return;
     }
 
     const features = [];
-    for (let _x = x - GRID_DIM_LAT; _x < x + GRID_DIM_LAT; _x++) {
-      for (let _y = y - GRID_DIM_LON; _y < y + GRID_DIM_LON; _y++) {
+    for (let _x = x - gridDimLat; _x < x + gridDimLat; _x++) {
+      for (let _y = y - gridDimLon; _y < y + gridDimLon; _y++) {
         const gwCoord = geoWebCoordinate.make_gw_coord(_x, _y);
         const coords = geoWebCoordinate.to_gps(gwCoord, GW_MAX_LAT, GW_MAX_LON);
         const gwCoordX = geoWebCoordinate.get_x(gwCoord);
@@ -503,7 +503,7 @@ function Map(props: MapProps) {
   }
 
   function _onMoveEnd(viewState: ViewState) {
-    if (viewState.zoom >= ZOOM_GRID_LEVEL) {
+    if (viewState.zoom >= gridZoomLevel) {
       updateGrid(viewport.latitude, viewport.longitude, grid, setGrid);
       setInteractiveLayerIds(["parcels-layer", "grid-layer"]);
     } else if (interactionState === STATE.VIEWING) {
@@ -726,7 +726,7 @@ function Map(props: MapProps) {
         } else {
           mapRef.current?.easeTo({
             center: [event.lngLat.lng, event.lngLat.lat],
-            zoom: ZOOM_GRID_LEVEL,
+            zoom: gridZoomLevel,
             duration: 500,
           });
         }
@@ -758,7 +758,7 @@ function Map(props: MapProps) {
       !mapRef?.current ||
       !claimBase1Coord ||
       !claimBase2Coord ||
-      viewport.zoom < ZOOM_GRID_LEVEL ||
+      viewport.zoom < gridZoomLevel ||
       interactionState !== STATE.CLAIM_SELECTING
     ) {
       return;
@@ -1014,7 +1014,7 @@ function Map(props: MapProps) {
     <>
       <OpRewardAlert />
       {interactionState === STATE.CLAIM_SELECTING &&
-        viewport.zoom < ZOOM_GRID_LEVEL && (
+        viewport.zoom < gridZoomLevel && (
           <Alert
             className="position-absolute top-50 start-50 text-center"
             variant="warning"
@@ -1174,7 +1174,7 @@ function Map(props: MapProps) {
         onClick={() =>
           mapRef.current?.easeTo({
             center: [viewport.longitude, viewport.latitude],
-            zoom: ZOOM_GRID_LEVEL,
+            zoom: gridZoomLevel,
             duration: 500,
           })
         }

--- a/lib/parcelNavigation.ts
+++ b/lib/parcelNavigation.ts
@@ -1,7 +1,6 @@
 import { gql, useQuery } from "@apollo/client";
 import { LngLatLike } from "mapbox-gl";
 import { useMap } from "react-map-gl";
-import { ZOOM_GRID_LEVEL } from "../components/Map";
 import { DRAWER_PREVIEW_HEIGHT_PARCEL } from "./constants";
 import { useMediaQuery } from "./mediaQuery";
 
@@ -80,11 +79,12 @@ function useParcelNavigation(parcelId?: string) {
     }
 
     const mapPadding = map.getPadding();
+    const zoomLevel = isMobile || isTablet ? 16 : 17;
 
     map.flyTo({
       center,
       duration,
-      zoom: isMobile || isTablet ? ZOOM_GRID_LEVEL - 1 : ZOOM_GRID_LEVEL,
+      zoom: zoomLevel,
       padding: {
         ...mapPadding,
         left: !isMobile && !isTablet ? document.body.offsetWidth * 0.25 : 0,


### PR DESCRIPTION
# Description

- Changes the zoom level from which the grid is drawn on mobile to be more zoomed out during the start of a claim selection.
- Changes the grid orientation to better fit mobile form factor while still computing the position of the same number of cells so the performance is unaffected.

# Issue

fixes #442 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
