### PR TITLE
fix: mobile safe signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mapbox/mapbox-gl-geocoder": "^5.0.1",
     "@orbisclub/components": "^0.1.60",
     "@popperjs/core": "^2.11.5",
-    "@rainbow-me/rainbowkit": "^0.12.17",
+    "@rainbow-me/rainbowkit": "^0.12.18",
     "@ramp-network/ramp-instant-sdk": "^4.0.3",
     "@reduxjs/toolkit": "^1.8.1",
     "@safe-global/protocol-kit": "^1.0.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -66,9 +66,9 @@ const connectors = connectorsForWallets([
     groupName: "Suggested",
     wallets: [
       injectedWallet({ chains }),
-      // metaMaskWallet({ chains, projectId: WALLET_CONNECT_PROJECT_ID }),
+      metaMaskWallet({ chains, projectId: WALLET_CONNECT_PROJECT_ID }),
       ledgerWallet({ chains, projectId: WALLET_CONNECT_PROJECT_ID }),
-      // walletConnectWallet({ chains, projectId: WALLET_CONNECT_PROJECT_ID }),
+      walletConnectWallet({ chains, projectId: WALLET_CONNECT_PROJECT_ID }),
       coinbaseWallet({ appName: "Geo Web Cadastre", chains }),
       braveWallet({ chains }),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6457,10 +6457,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@rainbow-me/rainbowkit@^0.12.17":
-  version "0.12.17"
-  resolved "https://registry.yarnpkg.com/@rainbow-me/rainbowkit/-/rainbowkit-0.12.17.tgz#42be3c151d8f4977c53133bd9077f7b5b735fd24"
-  integrity sha512-H5JT1caMTcAmjMTAYG9rDhZdNeNkfEwwYSbI/x+xfXaeQNqFeSePKHwl2jbrDiTlXWToxxT0AC2lp1b/4t0J9w==
+"@rainbow-me/rainbowkit@^0.12.18":
+  version "0.12.18"
+  resolved "https://registry.yarnpkg.com/@rainbow-me/rainbowkit/-/rainbowkit-0.12.18.tgz#a42f1682e629586fdebdc5606b0617f7f7e52054"
+  integrity sha512-Ehpr8gBCS8v4vdXLi8ZBlQ1yA6GHJOhoP66hLrdgI5iSlr6aUGTEicEfb2RaKNltHJFW/5A4BKst0AK4PkAkuw==
   dependencies:
     "@vanilla-extract/css" "1.9.1"
     "@vanilla-extract/dynamic" "2.0.2"


### PR DESCRIPTION
# Description

There is an issue with WalletConnect on mobile Metamask and the `eth_signTypeData_v4`method that we use to sign Safe transactions.
This checks if the user is on mobile or tablet and asks to sign with `eth_sign` if so.

# Issue

fixes #456 

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
