### PR TITLE
fix(governance): matching pool donation input validation

### DIFF
--- a/src/components/governance/EditStream.tsx
+++ b/src/components/governance/EditStream.tsx
@@ -384,11 +384,14 @@ export default function EditStream(props: EditStreamProps) {
     setAmount: (value: string) => void
   ) => {
     const { value } = e.target;
+    const valueWithoutCommas = value.replace(/,/g, "");
 
-    if (isNumber(value.replace(/,/g, ""))) {
+    if (isNumber(valueWithoutCommas)) {
       setAmount(
-        `${formatNumberWithCommas(parseFloat(value.replace(/,/g, "")))}${
-          isFundingMatchingPool && value.endsWith(".") ? "." : ""
+        `${
+          isFundingMatchingPool && parseFloat(valueWithoutCommas) < 1000
+            ? value
+            : formatNumberWithCommas(parseFloat(valueWithoutCommas))
         }`
       );
     } else if (value === "") {


### PR DESCRIPTION
# Description

Fixes a bug that caused the second decimal place in the matching pool donation input field to not be allowed to be inserted.

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
