### PR TITLE
feat(governance): add grantee twitter handle in share copy

### DIFF
--- a/src/components/governance/EditStream.tsx
+++ b/src/components/governance/EditStream.tsx
@@ -1399,8 +1399,6 @@ export default function EditStream(props: EditStreamProps) {
                 rel="noreferrer"
                 target="_blank"
                 href={`https://twitter.com/intent/tweet?text=I%20just%20opened%20a%20contribution%20stream%20to%20${
-                  isFundingMatchingPool ? "the SQF Matching Pool" : granteeName
-                }%20${
                   recipientsDetails && granteeIndex !== null
                     ? extractTwitterHandle(
                         recipientsDetails[granteeIndex].social

--- a/src/components/governance/EditStream.tsx
+++ b/src/components/governance/EditStream.tsx
@@ -1399,7 +1399,9 @@ export default function EditStream(props: EditStreamProps) {
                 rel="noreferrer"
                 target="_blank"
                 href={`https://twitter.com/intent/tweet?text=I%20just%20opened%20a%20contribution%20stream%20to%20${
-                  recipientsDetails && granteeIndex !== null
+                  isFundingMatchingPool
+                    ? "the SQF Matching Pool"
+                    : recipientsDetails && granteeIndex !== null
                     ? extractTwitterHandle(
                         recipientsDetails[granteeIndex].social
                       )

--- a/src/components/governance/EditStream.tsx
+++ b/src/components/governance/EditStream.tsx
@@ -54,6 +54,7 @@ import {
   convertStreamValueToInterval,
   sqrtBigInt,
   formatNumberWithCommas,
+  extractTwitterHandle,
 } from "../../lib/utils";
 import {
   DAI_ADDRESS,
@@ -111,7 +112,7 @@ export default function EditStream(props: EditStreamProps) {
 
   const { address } = useAccount();
   const { chain } = useNetwork();
-  const { passportDecoder } = useAllo();
+  const { passportDecoder, recipientsDetails } = useAllo();
   const { userTokenSnapshots } = useRoundQuery(address);
   const {
     nativeSuperToken,
@@ -1399,7 +1400,13 @@ export default function EditStream(props: EditStreamProps) {
                 target="_blank"
                 href={`https://twitter.com/intent/tweet?text=I%20just%20opened%20a%20contribution%20stream%20to%20${
                   isFundingMatchingPool ? "the SQF Matching Pool" : granteeName
-                }%20in%20the%20%23streamingqf%20pilot%20presented%20by%20%40thegeoweb%2C%20%40Superfluid_HQ%2C%20%26%20%40gitcoin%3A%0A%0Ahttps%3A%2F%2Fgeoweb.land%2Fgovernance%2F%0A%0AJoin%20me%20in%20making%20public%20goods%20funding%20history%20by%20donating%20in%20the%20world%27s%20first%20SQF%20round%21`}
+                }%20${
+                  recipientsDetails && granteeIndex !== null
+                    ? extractTwitterHandle(
+                        recipientsDetails[granteeIndex].social
+                      )
+                    : ""
+                }%20in%20the%20%23streamingqf%20pilot%20presented%20by%20%40thegeoweb%2C%20%40Superfluid_HQ%2C%20%26%20%40gitcoin%3A%0A%0Ahttps%3A%2F%2Fgeoweb.land%2Fgovernance%0A%0AJoin%20me%20in%20making%20public%20goods%20funding%20history%20by%20donating%20in%20the%20world%27s%20first%20SQF%20round%21`}
                 data-size="large"
               >
                 <Image src={XIcon} alt="x social" width={28} height={22} />
@@ -1411,7 +1418,7 @@ export default function EditStream(props: EditStreamProps) {
                 target="_blank"
                 href={`https://warpcast.com/~/compose?text=I+just+opened+a+contribution+stream+to+${
                   isFundingMatchingPool ? "the SQF Matching Pool" : granteeName
-                }+in+the+%23streamingqf+pilot+round+presented+by+%40geoweb%2C+%40gitcoin%2C+%26+%40superfluid1%3A+%0A%0Ahttps%3A%2F%2Fgeoweb.land%2Fgovernance%2F+%0A%0AJoin+me+in+making+public+goods+funding+history+by+donating+in+the+world's+first+SQF+round%21`}
+                }+in+the+%23streamingqf+pilot+round+presented+by+%40geoweb%2C+%40gitcoin%2C+%26+%40superfluid1%3A+%0A%0Ahttps%3A%2F%2Fgeoweb.land%2Fgovernance+%0A%0AJoin+me+in+making+public+goods+funding+history+by+donating+in+the+world's+first+SQF+round%21`}
               >
                 <Image
                   src={FarcasterIcon}
@@ -1427,7 +1434,7 @@ export default function EditStream(props: EditStreamProps) {
                 target="_blank"
                 href={`https://hey.xyz/?text=I+just+opened+a+contribution+stream+to+${
                   isFundingMatchingPool ? "the SQF Matching Pool" : granteeName
-                }+in+the+%23streamingqf+pilot+round+presented+by+Geo+Web%2C+%40gitcoin%2C+%26+%40superfluid%3A+%0A%0Ahttps%3A%2F%2Fgeoweb.land%2Fgovernance%2F+%0A%0AJoin+me+in+making+public+goods+funding+history+by+donating+in+the+world%27s+first+SQF+round%21`}
+                }+in+the+%23streamingqf+pilot+round+presented+by+Geo+Web%2C+%40gitcoin%2C+%26+%40superfluid%3A+%0A%0Ahttps%3A%2F%2Fgeoweb.land%2Fgovernance+%0A%0AJoin+me+in+making+public+goods+funding+history+by+donating+in+the+world%27s+first+SQF+round%21`}
               >
                 <Image src={LensIcon} alt="lens" width={28} height={22} />
                 <span style={{ fontSize: "10px" }}>Post on Lens</span>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -217,3 +217,9 @@ export function formatNumberWithCommas(n: number) {
     fractional ?? ""
   }`;
 }
+
+export function extractTwitterHandle(url: string) {
+  if (!url) return null;
+  const match = url.match(/^https?:\/\/(www\.)?twitter.com\/@?(?<handle>\w+)/);
+  return match?.groups?.handle ? `@${match.groups.handle}` : null;
+}


### PR DESCRIPTION
# Description

- Adds the grantee's twitter handle in the social share copy after a successful donation.
- Remove the final slash from the link

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
