### PR TITLE
fix: do not sync MUD on mainnet or home page

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@didtools/cacao": "^1.1.0",
     "@didtools/pkh-ethereum": "^0.0.3",
     "@geo-web/mud-world-base-contracts": "0.1.0",
-    "@geo-web/mud-world-base-setup": "0.1.2",
+    "@geo-web/mud-world-base-setup": "0.2.2",
     "@geo-web/sdk": "^4.4.0",
     "@latticexyz/common": "2.0.0-next.11",
     "@latticexyz/protocol-parser": "2.0.0-next.11",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -7,14 +7,12 @@ export const WORLD = {
   blockNumber: import.meta.env.VITE_WORLD_BLOCK_NUMBER,
 };
 export const RPC_URLS_HTTP: Record<number, string> = {
-  10: `https://optimism-rpc.publicnode.com`,
-  11155420: `https://optimism-sepolia-rpc.publicnode.com`,
+  10: import.meta.env.VITE_RPC_URL_HTTP_MAINNET!,
+  11155420: import.meta.env.VITE_RPC_URL_HTTP_TESTNET!,
 };
 export const RPC_URLS_WS: Record<number, string> = {
-  10: `wss://opt-mainnet.g.alchemy.com/v2/${import.meta.env
-    .VITE_ALCHEMY_API_KEY!}`,
-  11155420: `wss://opt-sepolia.g.alchemy.com/v2/${import.meta.env
-    .VITE_ALCHEMY_API_KEY!}`,
+  10: import.meta.env.VITE_RPC_URL_WS_MAINNET!,
+  11155420: import.meta.env.VITE_RPC_URL_WS_TESTNET!,
 };
 export const SPATIAL_DOMAIN = import.meta.env.VITE_SPATIAL_DOMAIN!;
 export const SSX_HOST = import.meta.env.VITE_SSX_HOST!;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -363,6 +363,8 @@ function IndexPage(props: IndexPageProps) {
         world: WORLD,
         namespaces: [Number(selectedParcelId).toString()],
         indexerUrl: "https://mud-testnet.geoweb.network/trpc",
+        startSync:
+          selectedParcelId !== "" && import.meta.env.MODE !== "mainnet",
       });
 
       setWorldConfig(worldConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2771,10 +2771,10 @@
     "@openzeppelin/contracts" "^4.9.3"
     ethers "^5.7.2"
 
-"@geo-web/mud-world-base-setup@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@geo-web/mud-world-base-setup/-/mud-world-base-setup-0.1.2.tgz#4321e59b3fde87c0d268a91e6c5eff91e0b6e7cf"
-  integrity sha512-Bnt+eH6eyYu7uGFuf6N/HrXccwbeCzWCCjb+9T3vwyHlpvCcME2vB5pYr8d58kdkgicHQSONk2u0+XenYE69ww==
+"@geo-web/mud-world-base-setup@0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@geo-web/mud-world-base-setup/-/mud-world-base-setup-0.2.2.tgz#d429df6ffbbe3f52c47d25e6fa8ca66e062b3093"
+  integrity sha512-1FIOMY0FW1kFj+43oJXm0wsF+Py39GyaQGrOsoS+DyOSaszoqVECs5geRAXIZLuDCv3IFsb8H7SgcSzSfzmkyg==
   dependencies:
     "@ethersproject/providers" "^5.7.2"
     "@geo-web/mud-world-base-contracts" "0.1.0"


### PR DESCRIPTION
# Description

Disables MUD syncing on mainnet and until a parcel is actually selected.

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it

# Alert Reviewers

@tnrdd @gravenp
