### PR TITLE
feat(governance): add QF multiplier to to transaction details view

### DIFF
--- a/src/components/governance/EditStream.tsx
+++ b/src/components/governance/EditStream.tsx
@@ -39,6 +39,7 @@ import AddIcon from "../../assets/add.svg";
 import RemoveIcon from "../../assets/remove.svg";
 import { MatchingData } from "./StreamingQuadraticFunding";
 import useFlowingAmount from "../../hooks/flowingAmount";
+import useEthPrice from "../../hooks/ethPrice";
 import useSuperfluid from "../../hooks/superfluid";
 import useTransactionsQueue from "../../hooks/transactionsQueue";
 import useAllo from "../../hooks/allo";
@@ -54,6 +55,7 @@ import {
   roundWeiAmount,
   convertStreamValueToInterval,
   sqrtBigInt,
+  absBigInt,
   formatNumberWithCommas,
   extractTwitterHandle,
 } from "../../lib/utils";
@@ -162,6 +164,7 @@ export default function EditStream(props: EditStreamProps) {
       enabled: address ? true : false,
       watch: false,
     });
+  const ethPrice = useEthPrice();
   useDonationAnalyticsEvent(step, isFundingMatchingPool);
 
   const minEthBalance = 0.001;
@@ -1265,18 +1268,18 @@ export default function EditStream(props: EditStreamProps) {
                     !isFundingMatchingPool ? "rounded-top-4" : "rounded-4"
                   }`}
                 >
-                  <Card.Text className="w-33 m-0 fs-5">New Stream</Card.Text>
+                  <Card.Text className="m-0 fs-5">New Stream</Card.Text>
                   <Stack
                     direction="horizontal"
                     gap={1}
-                    className="w-50 ms-2 p-2"
+                    className="justify-content-end w-50 ms-2 p-2"
                   >
                     <Image
                       src={superTokenIcon}
                       alt={isFundingMatchingPool ? "eth" : "dai"}
                       width={isFundingMatchingPool ? 16 : 22}
                     />
-                    <Badge className="bg-aqua w-100 ps-2 pe-2 py-2 fs-4 text-start overflow-hidden text-truncate">
+                    <Badge className="bg-aqua w-75 ps-2 pe-2 py-2 fs-4 text-start overflow-hidden text-truncate">
                       {formatNumberWithCommas(
                         parseFloat(
                           convertStreamValueToInterval(
@@ -1291,39 +1294,75 @@ export default function EditStream(props: EditStreamProps) {
                   <Card.Text className="m-0 ms-1 fs-5">/month</Card.Text>
                 </Stack>
                 {!isFundingMatchingPool && (
-                  <Stack
-                    direction="horizontal"
-                    className="bg-purple rounded-bottom-4 border-top border-dark p-2"
-                  >
-                    <Card.Text className="w-33 m-0 fs-5">
-                      Est. Matching
-                    </Card.Text>
+                  <>
                     <Stack
                       direction="horizontal"
-                      gap={1}
-                      className="w-50 ms-1 p-2"
+                      className="bg-purple border-top border-dark p-2"
                     >
-                      <Image
-                        src={ETHLogo}
-                        alt="eth"
-                        width={18}
-                        className="mx-1"
-                      />
-                      <Badge className="bg-slate w-100 ps-2 pe-2 py-2 fs-4 text-start">
-                        {passportScore && passportScore < minPassportScore
-                          ? "N/A"
-                          : netImpact
-                          ? `${netImpact > 0 ? "+" : ""}${parseFloat(
-                              (
-                                Number(formatEther(netImpact)) *
-                                fromTimeUnitsToSeconds(1, "months")
-                              ).toFixed(6)
-                            )}`
-                          : 0}
-                      </Badge>
+                      <Card.Text className="m-0 fs-5">Est. Matching</Card.Text>
+                      <Stack
+                        direction="horizontal"
+                        gap={1}
+                        className="justify-content-end w-50 ms-1 p-2"
+                      >
+                        <Image
+                          src={ETHLogo}
+                          alt="eth"
+                          width={14}
+                          className="mx-1"
+                        />
+                        <Badge className="bg-slate w-75 ps-2 pe-2 py-2 fs-4 text-start">
+                          {passportScore && passportScore < minPassportScore
+                            ? "N/A"
+                            : netImpact
+                            ? `${netImpact > 0 ? "+" : ""}${parseFloat(
+                                (
+                                  Number(formatEther(netImpact)) *
+                                  fromTimeUnitsToSeconds(1, "months")
+                                ).toFixed(6)
+                              )}`
+                            : 0}
+                        </Badge>
+                      </Stack>
+                      <Card.Text className="m-0 ms-1 fs-5">/month</Card.Text>
                     </Stack>
-                    <Card.Text className="m-0 ms-1 fs-5">/month</Card.Text>
-                  </Stack>
+                    <Stack
+                      direction="horizontal"
+                      className="bg-purple rounded-bottom-4 border-top border-dark p-2"
+                    >
+                      <Card.Text className="m-0 fs-5">QF Multiplier</Card.Text>
+                      <Stack
+                        direction="horizontal"
+                        gap={1}
+                        className="justify-content-end w-50 ms-2 p-2"
+                      >
+                        <Badge
+                          className={`w-75 ps-2 pe-2 py-2 fs-4 text-start ${
+                            BigInt(newFlowRate) < BigInt(flowRateToReceiver)
+                              ? "bg-danger"
+                              : "bg-slate"
+                          }`}
+                        >
+                          {netImpact &&
+                          Number(ethPrice) > 0 &&
+                          newFlowRate !== flowRateToReceiver
+                            ? `~${parseFloat(
+                                (
+                                  (Number(absBigInt(netImpact)) *
+                                    Number(ethPrice)) /
+                                  Number(
+                                    absBigInt(
+                                      BigInt(newFlowRate) -
+                                        BigInt(flowRateToReceiver)
+                                    )
+                                  )
+                                ).toFixed(2)
+                              )}x`
+                            : "N/A"}
+                        </Badge>
+                      </Stack>
+                    </Stack>
+                  </>
                 )}
               </Stack>
               {liquidationEstimate && (

--- a/src/components/governance/MatchingPoolDetails.tsx
+++ b/src/components/governance/MatchingPoolDetails.tsx
@@ -168,7 +168,7 @@ export default function MatchingPoolDetails(props: MatchingPoolDetailsProps) {
             )}
           </Badge>
         </Stack>
-        <Card.Text className="w-20 mt-3">total funding</Card.Text>
+        <Card.Text className="mt-3">total funding</Card.Text>
       </Stack>
       <Card.Text className="m-0 p-2 fs-5" style={{ maxWidth: 500 }}>
         Streaming Quadratic Funding is a collaboration between Superfluid,

--- a/src/components/governance/Profile.tsx
+++ b/src/components/governance/Profile.tsx
@@ -322,7 +322,7 @@ function Profile(props: ProfileProps) {
               alt="token logo"
               width={token === Token.ETHx ? 15 : 22}
             />
-            <Card.Text className="m-0 text-white w-33 overflow-hidden text-truncate">
+            <Card.Text className="m-0 text-white overflow-hidden text-truncate">
               {token === Token.ETHx
                 ? formatNumberWithCommas(
                     parseFloat(formatEther(superTokenBalanceNative).slice(0, 8))
@@ -382,7 +382,7 @@ function Profile(props: ProfileProps) {
           <Card.Text className="m-0 text-gray px-2 w-50">
             Liquidation Date
           </Card.Text>
-          <Card.Text className="m-0 text-gray w-33 overflow-hidden text-truncate fs-4">
+          <Card.Text className="m-0 text-gray overflow-hidden text-truncate fs-4">
             {token === Token.ETHx &&
             accountInfoNative?.data[0]?.maybeCriticalAtTimestamp
               ? dayjs

--- a/src/components/governance/RecipientDetails.tsx
+++ b/src/components/governance/RecipientDetails.tsx
@@ -183,7 +183,7 @@ export default function RecipientDetails(props: RecipientDetailsProps) {
             )}
           </Badge>
         </Stack>
-        <Card.Text className="w-20 mt-3">total funding</Card.Text>
+        <Card.Text className="mt-3">total funding</Card.Text>
       </Stack>
       <Card.Text className="m-0 p-2 fs-5" style={{ maxWidth: 500 }}>
         <>

--- a/src/hooks/ethPrice.ts
+++ b/src/hooks/ethPrice.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from "react";
+
+export default function useEthPrice() {
+  const [ethPrice, setEthPrice] = useState();
+
+  useEffect(() => {
+    const fetchPrice = async () => {
+      try {
+        const res = await fetch(
+          "https://api.exchange.coinbase.com/products/eth-dai/ticker"
+        );
+        const ethPrice = (await res.json()).price;
+
+        setEthPrice(ethPrice);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    const timerId = setInterval(fetchPrice, 10000);
+
+    fetchPrice();
+
+    return () => clearInterval(timerId);
+  }, []);
+
+  return ethPrice;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -175,6 +175,10 @@ export function sqrtBigInt(s: bigint) {
   return x0;
 }
 
+export function absBigInt(n: bigint) {
+  return n < 0n ? -n : n;
+}
+
 export function clampText(str: string, newLength: number) {
   if (str.length <= newLength) {
     return str;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -63,6 +63,32 @@ $accordion-icon-active-color: $light;
 }
 
 @import "bootstrap/scss/bootstrap";
+@import "bootstrap/scss/utilities";
+
+$utilities: map-merge(
+  $utilities,
+  (
+    "width": (
+      property: width,
+      class: w,
+      responsive: true,
+      values: (
+        10: 10%,
+        20: 20%,
+        25: 25%,
+        33: 33%,
+        50: 50%,
+        66: 66%,
+        75: 75%,
+        90: 90%,
+        100: 100%,
+        auto: auto,
+      ),
+    ),
+  )
+);
+
+@import "bootstrap/scss/utilities/api";
 
 html,
 body {


### PR DESCRIPTION
# Description

Add a field to the transaction details view of the donation stream flow to show the absolute QF multiplier of the user marginal change in the stream.
The ETHDAI price is fetched from Coinbase REST API, it's used to convert the matching pool amount from ETH to DAI and calculate the multiplier.

# Checklist:

- [x] My commit message follows the Conventional Commits specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code
- [x] My changes generate no new warnings
- [x] My PR is rebased off the most recent `develop` branch
- [x] My PR is opened against the `develop` branch

# Alert Reviewers

@codynhat @gravenp
